### PR TITLE
Allow single scalar type in arrayType

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Sometimes that works out, but other times the distinction between the two greatl
 
 #### `arrayType`
 
-On both a `#[SequenceField]` and `#[DictionaryField]`, the `arrayType` argument lets you specify the class that all values in that structure are.  For example, a sequence of integers can easily be serialized to and deserialized from most formats without any additional help.  However, an ordered list of `Product` objects could be serialized, but there's no way to tell then how to deserialize that data back to `Product` objects rather than just a nested associative array (which would also be legal).  The `arrayType` argument solves that issue.
+On both a `#[SequenceField]` and `#[DictionaryField]`, the `arrayType` argument lets you specify the class or single scalar type (via `ScalarType`) that all values in that structure are.  For example, a sequence of integers can easily be serialized to and deserialized from most formats without any additional help, but specifying `ScalarType::Int` will ensure that upon deserialization there will be only int values in the array.  However, an ordered list of `Product` objects could be serialized, but there's no way to tell then how to deserialize that data back to `Product` objects rather than just a nested associative array (which would also be legal).  The `arrayType` argument solves that issue.
 
 If `arrayType` is specified, then all values of that array are assumed to be of that type.  On deserialization, then, Serde will look for nested object-like structures (depending on the specific format), and convert those into the specified object type.
 
@@ -445,6 +445,9 @@ In this case, the attribute tells Serde that `$products` is an indexed, sequenti
 When deserializing, the otherwise object-ignorant data will be upcast back to `Product` objects.
 
 `arrayType` works the exact same way on a `DictionaryField`.
+
+When using `ScalarType` then all values have to conform to the single type, no exceptions are allowed not even `null` values. Any divergence will cause an exception to be thrown.
+Also beware that if the property is set to not match `arrayType` then this will be also serialized out!
 
 #### `keyType`
 

--- a/src/Attributes/DictionaryField.php
+++ b/src/Attributes/DictionaryField.php
@@ -7,6 +7,7 @@ namespace Crell\Serde\Attributes;
 use Attribute;
 use Crell\AttributeUtils\SupportsScopes;
 use Crell\Serde\KeyType;
+use Crell\Serde\ScalarType;
 use Crell\Serde\TypeField;
 use function Crell\fp\afilter;
 use function Crell\fp\amap;
@@ -20,7 +21,7 @@ use function Crell\fp\reduce;
 class DictionaryField implements TypeField, SupportsScopes
 {
     /**
-     * @param string|null $arrayType
+     * @param ScalarType|string|null $arrayType
      *   Elements in this array are objects of this type.
      * @param string|null $implodeOn
      *   Scalar values of this array should be imploded to a string and exploded on deserialization.
@@ -32,7 +33,7 @@ class DictionaryField implements TypeField, SupportsScopes
      *   The scopes in which this attribute should apply.
      */
     public function __construct(
-        public readonly ?string $arrayType = null,
+        public readonly ScalarType|string|null $arrayType = null,
         public readonly ?KeyType $keyType = null,
         public readonly ?string $implodeOn = null,
         public readonly ?string $joinOn = null,

--- a/src/Attributes/SequenceField.php
+++ b/src/Attributes/SequenceField.php
@@ -6,13 +6,14 @@ namespace Crell\Serde\Attributes;
 
 use Attribute;
 use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\ScalarType;
 use Crell\Serde\TypeField;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class SequenceField implements TypeField, SupportsScopes
 {
     /**
-     * @param string|null $arrayType
+     * @param ScalarType|string|null $arrayType
      *   Elements in this array are objects of this type.
      * @param string|null $implodeOn
      *   Scalar values of this array should be imploded to a string and exploded on deserialization.
@@ -22,7 +23,7 @@ class SequenceField implements TypeField, SupportsScopes
      *   The scopes in which this attribute should apply.
      */
     public function __construct(
-        public readonly ?string $arrayType = null,
+        public readonly null|string|ScalarType $arrayType = null,
         public readonly ?string $implodeOn = null,
         public readonly bool $trim = true,
         protected readonly array $scopes = [null],

--- a/src/ScalarType.php
+++ b/src/ScalarType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+enum ScalarType: string
+{
+    case String = 'string';
+
+    case Int = 'int';
+
+    case Float = 'float';
+
+    case Bool = 'bool';
+}

--- a/tests/ArrayBasedFormatterTest.php
+++ b/tests/ArrayBasedFormatterTest.php
@@ -398,4 +398,13 @@ abstract class ArrayBasedFormatterTest extends SerdeTest
 
         self::assertNull($toTest['arr'][0]);
     }
+
+    public function array_of_scalar_values_serializes_cleanly_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+        self::assertCount(3, $toTest['ints']);
+        self::assertCount(3, $toTest['strings']);
+        self::assertCount(3, $toTest['floats']);
+        self::assertCount(3, $toTest['bools']);
+    }
 }

--- a/tests/Records/ScalarArraysObject.php
+++ b/tests/Records/ScalarArraysObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\ScalarType;
+
+class ScalarArraysObject
+{
+    public function __construct(
+        #[SequenceField(arrayType: ScalarType::Int)]
+        public array $ints = [],
+        #[SequenceField(arrayType: ScalarType::String)]
+        public array $strings = [],
+        #[SequenceField(arrayType: ScalarType::Float)]
+        public array $floats = [],
+        #[SequenceField(arrayType: ScalarType::Bool)]
+        public array $bools = [],
+    ) {
+    }
+}

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -53,6 +53,7 @@ use Crell\Serde\Records\Pagination\Results;
 use Crell\Serde\Records\Point;
 use Crell\Serde\Records\RootMap\Type;
 use Crell\Serde\Records\RootMap\TypeB;
+use Crell\Serde\Records\ScalarArraysObject;
 use Crell\Serde\Records\Shapes\Box;
 use Crell\Serde\Records\Shapes\Circle;
 use Crell\Serde\Records\Shapes\Rectangle;
@@ -1205,6 +1206,105 @@ abstract class SerdeTest extends TestCase
         $s = new SerdeCommon(formatters: $this->formatters);
 
         $result = $s->deserialize($this->invalidDictStringKey, $this->format, DictionaryKeyTypes::class);
+    }
+
+    /**
+     * @test
+     */
+    public function array_of_scalar_values_serializes_cleanly(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArraysObject(
+            ints: [1, 2, 3],
+            strings: ['a', 'b', 'c'],
+            floats: [1.1, 2.2, 3.3],
+            bools: [true, false, true],
+        );
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->array_of_scalar_values_serializes_cleanly_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: ScalarArraysObject::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function array_of_scalar_values_serializes_cleanly_validate(mixed $serialized): void
+    {
+
+    }
+
+    /**
+     * @test
+     */
+    public function array_of_scalar_values_invalid_int_value(): void
+    {
+        $this->expectException(TypeMismatch::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArraysObject(
+            ints: [1, "2"],
+            strings: [],
+            floats: [],
+            bools: [],
+        );
+        $serialized = $s->serialize($data, $this->format);
+        $s->deserialize($serialized, $this->format, ScalarArraysObject::class);
+    }
+
+    /**
+     * @test
+     */
+    public function array_of_scalar_values_invalid_string_value(): void
+    {
+        $this->expectException(TypeMismatch::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArraysObject(
+            ints: [],
+            strings: [1, "2"],
+            floats: [],
+            bools: [],
+        );
+        $serialized = $s->serialize($data, $this->format);
+        $s->deserialize($serialized, $this->format, ScalarArraysObject::class);
+    }
+
+    public function array_of_scalar_values_invalid_float_value(): void
+    {
+        $this->expectException(TypeMismatch::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArraysObject(
+            ints: [],
+            strings: [],
+            floats: [1.1, "2.2"],
+            bools: [],
+        );
+        $serialized = $s->serialize($data, $this->format);
+        $s->deserialize($serialized, $this->format, ScalarArraysObject::class);
+    }
+
+
+    public function array_of_scalar_values_invalid_bool_value(): void
+    {
+        $this->expectException(TypeMismatch::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArraysObject(
+            ints: [],
+            strings: [],
+            floats: [],
+            bools: [true, "false"],
+        );
+        $serialized = $s->serialize($data, $this->format);
+        $s->deserialize($serialized, $this->format, ScalarArraysObject::class);
     }
 
     /**


### PR DESCRIPTION
## Description

To allow proper type check of the Sequence and Dictionary value types -- limited to single scalar type for now.

Solves #12.

## Motivation and context

When obtaining data from or on the API I want map them to an array of strings/ints/bool for further use in some cases... Without this any value can be pushed to deserialization leading to failures later or needing for another validation (i.e symfony/validator).

## How has this been tested?

- Added test cases
- Manual testing

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The behaviour has changed:
- `arrayType` can have `ScalarType` with just single scalar type, anything else is still considered as class or interface.
- when invalid value (including `null`) is come across the exception is thrown.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
