### PR TITLE
Support iterables as properties and add CSV formatters

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -17,7 +17,6 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  coverage: xdebug
                   tools: composer:v2
             - run: composer update --no-progress ${{ matrix.composer-flags }}
             - run: vendor/bin/phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to `Serde` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 0.5.0 - YYYY-MM-DD
+## 0.6.0 - YYYY-MM-DD
+
+### Added
+- Support for iterable properties, including generators.
+- Support for serializing/deserializing from CSV files.
+- Support for stream-serializing to a CSV format.
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
+
+## 0.5.0 - 2022-07-22
 
 ### Added
 - Dictionary fields can now be restricted to just string or just integer keys.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Serde (pronounced "seer-dee") is a fast, flexible, powerful, and easy to use serialization and deserialization library for PHP that supports a number of standard formats.  It draws inspiration from both Rust's Serde crate and Symfony Serializer, although it is not directly based on either.
 
-At this time, Serde supports serializing PHP objects to and from PHP arrays, JSON, and YAML.  It also supports serializing to JSON via a stream.  Further support is planned, but by design can also be extended by anyone.
+At this time, Serde supports serializing PHP objects to and from PHP arrays, JSON, YAML, and CSV files.  It also supports serializing to JSON or CSV via a stream.  Further support is planned, but by design can also be extended by anyone.
 
 Serde is currently in late-beta.  It's possible there will be some small API changes still, but it should be mostly-stable and safe to use.
 
@@ -50,6 +50,7 @@ Serde can serialize to:
 * Streaming JSON (`json-stream`)
 * YAML (`yaml`)
 * CSV (`csv`)
+* Streaming CSV (`csv-stream`)
 
 Serde can deserialize from:
 
@@ -561,6 +562,83 @@ This combination will result in a three-column CSV file, and also deserialize fr
 The CSV formatter uses PHP's native CSV parsing and writing tools.  If you want to control the delimiters used, pass those as constructor arguments to a `CsvFormatter` instance and inject that into the `Serde` class instead of the default.
 
 Note that the lone property may be a generator.  That allows a CSV to be generated on the fly off of arbitrary data.  When deserialized, it will still deserialize to an array.
+
+### Streams
+
+Serde includes two stream-based formatters (but not deformatters, yet), one for JSON and one for CSV.  They work nearly the same way as any other formatter, but when calling `$serde->serialize()` you may (and should) pass an extra `init` argument.  `$init` should be an instance of `Serde\Formatter\FormatterStream`, which wraps a writeable PHP stream handle.
+
+The value returned will then be that same stream handle, after the object to be serialized has been written to it.
+
+For example:
+
+```php
+// The JsonStreamFormatter and CsvStreamFormatter are not included by default.
+$s = new SerdeCommon(formatters: [new JsonStreamFormatter()]);
+
+// You may use any PHP supported stream here, including files, network sockets,
+// stdout, an in-memory temp stream, etc.
+$init = FormatterStream::new(fopen('/tmp/output.json', 'wb'));
+
+$result = $serde->serialize($data, format: 'json-stream', init: $init);
+
+// $result is a FormatterStream object that wraps the same handle as before.
+// What you can now do with the stream depends on what kind of stream it is.
+```
+
+In this example, the `$data` object (whatever it is) gets serialized to JSON piecemeal and streamed out to the specified file handle.
+
+The `CsvStreamFormatter` works in the exact same way, but outputs CSV data and has the same restrictions as the `CsvFormatter` in terms of the objects it accepts.
+
+In many cases that won't actually offer much benefit, as the whole object must be in memory anyway.  However, it may be combined with the support for lazy iterators to have a property that produces objects lazily, say from a database query or read from some other source.
+
+Consider this example:
+
+```php
+use Crell\Serde\Attributes\SequenceField;
+
+class ProductList
+{
+    public function __construct(
+        #[SequenceField(arrayType: Product::class)]
+        private iterable $products,
+    ) {}
+}
+
+class Product
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $color,
+        public readonly float $price,
+    ) {}
+}
+
+$databaseConn = ...;
+
+$callback = function() use ($databaseConn) {
+    $result = $databaseConn->query("SELECT name, color, price FROM products ORDER BY name");
+
+    // Assuming $record is an associative array.
+    foreach ($result as $record) {
+        yield new Product(...$record);
+    }
+};
+
+// This is a lazy list of products, which will be pulled from the database.
+$products = new ProductList($callback());
+
+// Use the CSV formatter this time, but JsonStream works just as well.
+$s = new SerdeCommon(formatters: [new CsvStreamFormatter()]);
+
+// Write to stdout, aka, back to the browser.
+$init = FormatterStream::new(fopen('php://output', 'wb'));
+
+$result = $serde->serialize($products, format: 'csv-stream', init: $init);
+```
+
+This setup will lazily pull records out of the database and instantiate an object from them, then lazily stream that data out to stdout.  No matter how many product records are in the database, the memory usage remains roughly constant.  (Note the database driver may do its own buffering of the entire result set, which could cause memory issues.  That's a separate matter, however.)
+
+While likely overkill for CSV, it can work very well for more involved objects being serialized to JSON.
 
 ### TypeMaps
 

--- a/README.md
+++ b/README.md
@@ -544,7 +544,6 @@ class CsvTable
         #[SequenceField(arrayType: CsvRow::class)]
         public array $people,
     ) {}
-
 }
 
 class CsvRow
@@ -560,6 +559,8 @@ class CsvRow
 This combination will result in a three-column CSV file, and also deserialize from a three-column CSV file.
 
 The CSV formatter uses PHP's native CSV parsing and writing tools.  If you want to control the delimiters used, pass those as constructor arguments to a `CsvFormatter` instance and inject that into the `Serde` class instead of the default.
+
+Note that the lone property may be a generator.  That allows a CSV to be generated on the fly off of arbitrary data.  When deserialized, it will still deserialize to an array.
 
 ### TypeMaps
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpbench/phpbench": "^1.1.2",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "~9.0",
         "symfony/yaml": "^5.3",
         "vishnubob/wait-for-it": "dev-master"

--- a/src/Attributes/DictionaryField.php
+++ b/src/Attributes/DictionaryField.php
@@ -110,7 +110,9 @@ class DictionaryField implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'array';
+        return $type === 'array'
+            || $type === 'iterable'
+            || is_a($type, \Traversable::class, true);
     }
 
     /**

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -273,7 +273,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         return match (true) {
             in_array($this->phpType, ['int', 'float', 'bool', 'string'], true) => TypeCategory::Scalar,
             $this->phpType === 'array' => TypeCategory::Array,
-            $this->phpType === 'iterable', is_a($this->phpType, \Traversable::class, true) => TypeCategory::Iterable,
+            $this->phpType === 'iterable', is_a($this->phpType, \Generator::class, true) => TypeCategory::Generator,
             \enum_exists($this->phpType) => $this->enumType($this->phpType),
             $this->phpType === 'object', \class_exists($this->phpType), \interface_exists($this->phpType) => TypeCategory::Object,
             $this->phpType === 'null' => TypeCategory::Null,

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -273,6 +273,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         return match (true) {
             in_array($this->phpType, ['int', 'float', 'bool', 'string'], true) => TypeCategory::Scalar,
             $this->phpType === 'array' => TypeCategory::Array,
+            $this->phpType === 'iterable', is_a($this->phpType, \Traversable::class, true) => TypeCategory::Iterable,
             \enum_exists($this->phpType) => $this->enumType($this->phpType),
             $this->phpType === 'object', \class_exists($this->phpType), \interface_exists($this->phpType) => TypeCategory::Object,
             $this->phpType === 'null' => TypeCategory::Null,

--- a/src/Attributes/SequenceField.php
+++ b/src/Attributes/SequenceField.php
@@ -30,7 +30,9 @@ class SequenceField implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'array';
+        return $type === 'array'
+            || $type === 'iterable'
+            || is_a($type, \Traversable::class, true);
     }
 
     public function shouldImplode(): bool

--- a/src/CsvFormatRequiresExplicitRowType.php
+++ b/src/CsvFormatRequiresExplicitRowType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+
+class CsvFormatRequiresExplicitRowType extends \InvalidArgumentException
+{
+    public readonly ClassSettings $classDef;
+    public readonly Field $rowField;
+
+    public static function create(ClassSettings $classDef, Field $rowField): self
+    {
+        $new = new self();
+        $new->classDef = $classDef;
+        $new->rowField = $rowField;
+
+        $new->message = sprintf('While trying to use %s with a CSV format, the %s field must be marked as a SequenceField and must have an explicit arrayType that specifies a class.', $classDef->phpType, $rowField->phpName);
+
+        return $new;
+    }
+}

--- a/src/Formatter/ArrayFormatter.php
+++ b/src/Formatter/ArrayFormatter.php
@@ -6,6 +6,7 @@ namespace Crell\Serde\Formatter;
 
 use Crell\Serde\Attributes\ClassSettings;
 use Crell\Serde\Attributes\Field;
+use Crell\Serde\Deserializer;
 
 class ArrayFormatter implements Formatter, Deformatter, SupportsCollecting
 {
@@ -46,7 +47,12 @@ class ArrayFormatter implements Formatter, Deformatter, SupportsCollecting
     /**
      * @return array<string, mixed>
      */
-    public function deserializeInitialize(mixed $serialized, Field $rootField): array
+    public function deserializeInitialize(
+        mixed $serialized,
+        ClassSettings $classDef,
+        Field $rootField,
+        Deserializer $deserializer
+    ): array
     {
         return ['root' => $serialized ?: []];
     }

--- a/src/Formatter/CsvFormatter.php
+++ b/src/Formatter/CsvFormatter.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Formatter;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\CsvFormatRequiresExplicitRowType;
+use Crell\Serde\Deserializer;
+use function Crell\fp\amap;
+use function Crell\fp\explode;
+use function Crell\fp\pipe;
+
+class CsvFormatter implements Formatter, Deformatter, SupportsCollecting
+{
+    use ArrayBasedFormatter;
+    use ArrayBasedDeformatter;
+
+    /**
+     *
+     * @param string $separator
+     *   The optional delimiter parameter sets the field
+     *   delimiter (one character only).
+     * @param string $enclosure
+     *   The optional enclosure parameter sets the field
+     *   enclosure (one character only).
+     * @param string $escape
+     *   The optional escape_char parameter sets the escape character (one character only).
+     * @param string $eol
+     *   The end-of-line character to use.
+     */
+    public function __construct(
+        private readonly string $separator = ",",
+        private readonly string $enclosure = '"',
+        private readonly string $escape = "\\",
+        private readonly string $eol = PHP_EOL
+    ) {}
+
+    public function format(): string
+    {
+        return 'csv';
+    }
+
+    /**
+     * @param Field $rootField
+     * @return array<string, mixed>
+     */
+    public function serializeInitialize(ClassSettings $classDef, Field $rootField): array
+    {
+        return ['root' => []];
+    }
+
+    /**
+     * PHP's built-in csv writer only works on streams, so use a temp stream to let it.
+     */
+    public function serializeFinalize(mixed $runningValue, ClassSettings $classDef): string
+    {
+        $stream = fopen('php://temp/', 'wb') ?: throw new \RuntimeException('Failed to create temp stream.');
+
+        $records = $runningValue['root'][array_key_first($classDef->properties)];
+
+        foreach ($records as $line) {
+            fputcsv(stream: $stream, fields: $line, separator: $this->separator, enclosure: $this->enclosure, escape: $this->escape, eol: $this->eol);
+
+            //fputcsv($stream, $line, $this->separator, $this->enclosure, $this->escape, $this->eol);
+        }
+
+        fseek($stream, 0);
+        return stream_get_contents($stream) ?: throw new \RuntimeException('Failed to get stream contents.');
+    }
+
+    public function deserializeInitialize(
+        mixed $serialized,
+        ClassSettings $classDef,
+        Field $rootField,
+        Deserializer $deserializer
+    ): mixed
+    {
+        $rowField = $classDef->properties[array_key_first($classDef->properties)];
+
+        $typeField = $rowField->typeField;
+        if (! $typeField instanceof SequenceField) {
+            throw CsvFormatRequiresExplicitRowType::create($classDef, $rowField);
+        }
+        if (!$typeField->arrayType || !class_exists($typeField->arrayType)) {
+            throw CsvFormatRequiresExplicitRowType::create($classDef, $rowField);
+        }
+
+        /** @var class-string $rowType */
+        $rowType = $typeField->arrayType;
+
+        $rowDef = $deserializer->analyzer->analyze($rowType, ClassSettings::class);
+
+        $fieldNames = array_keys($rowDef->properties);
+
+        $rows = pipe(trim($serialized),
+            explode($this->eol),
+            amap(fn(string $line): array => str_getcsv($line, $this->separator, $this->enclosure, $this->escape)),
+            amap(fn(array $vals): array => amap($this->typeNormalize(...))($vals)),
+            amap(fn(array $vals): array => array_combine($fieldNames, $vals)),
+        );
+
+        return ['root' => [array_key_first($classDef->properties) => $rows]];
+    }
+
+    /**
+     * Normalizes a scalar value to its most-restrictive type.
+     *
+     * CSV values are always imported as strings, but if we want to
+     * push them into well-typed numeric fields we need to cast them
+     * appropriately.
+     *
+     * @param mixed $val
+     *   The value to normalize.
+     * @return int|float|string
+     *   The passed value, but now with the correct type.
+     */
+    private function typeNormalize(mixed $val): int|float|string
+    {
+        if (!is_numeric($val)) {
+            return $val;
+        }
+
+        // It's either a float or an int, but floor() wants a float.
+        $val = (float) $val;
+
+        // Deliberately not a strict comparison.
+        if (floor($val) == $val) {
+            return (int) $val;
+        }
+        return (float) $val;
+    }
+
+    public function deserializeFinalize(mixed $decoded): void
+    {
+
+    }
+}

--- a/src/Formatter/CsvStreamFormatter.php
+++ b/src/Formatter/CsvStreamFormatter.php
@@ -14,6 +14,13 @@ use function Crell\fp\headtail;
 use function Crell\fp\reduce;
 use function Crell\fp\reduceWithKeys;
 
+/**
+ * Writes CSV data to a stream handle.
+ *
+ * This class currently makes no optimizations for the fact
+ * that the possible structure is so simple, and the existence
+ * of PHP's csv functions.  That should be considered for optimization.
+ */
 class CsvStreamFormatter implements Formatter
 {
     use StreamFormatter;

--- a/src/Formatter/CsvStreamFormatter.php
+++ b/src/Formatter/CsvStreamFormatter.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Formatter;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\CollectionItem;
+use Crell\Serde\Dict;
+use Crell\Serde\Sequence;
+use Crell\Serde\Serializer;
+use function Crell\fp\headtail;
+use function Crell\fp\reduce;
+use function Crell\fp\reduceWithKeys;
+
+class CsvStreamFormatter implements Formatter
+{
+    use StreamFormatter;
+
+    /**
+     *
+     * @param string $separator
+     *   The optional delimiter parameter sets the field
+     *   delimiter (one character only).
+     * @param string $enclosure
+     *   The optional enclosure parameter sets the field
+     *   enclosure (one character only).
+     * @param string $escape
+     *   The optional escape_char parameter sets the escape character (one character only).
+     * @param string $eol
+     *   The end-of-line character to use.
+     */
+    public function __construct(
+        private readonly string $separator = ",",
+        private readonly string $enclosure = '"',
+        private readonly string $escape = "\\",
+        private readonly string $eol = PHP_EOL
+    ) {}
+
+    public function format(): string
+    {
+        return 'csv-stream';
+    }
+
+    /**
+     * @param FormatterStream $runningValue
+     */
+    public function serializeString(mixed $runningValue, Field $field, string $next): mixed
+    {
+        $next = str_replace($this->enclosure, $this->escape . $this->enclosure, $next);
+        $runningValue->write($this->enclosure . $next . $this->enclosure);
+        return $runningValue;
+    }
+
+    /**
+     * @param FormatterStream $runningValue
+     */
+    public function serializeSequence(mixed $runningValue, Field $field, Sequence $next, Serializer $serializer): FormatterStream
+    {
+        return reduce($runningValue, static fn (FormatterStream $runningValue, CollectionItem $item)
+            =>  $serializer->serialize($item->value, $runningValue, $item->field)
+        )($next->items);
+
+    }
+
+    /**
+     * @param FormatterStream $runningValue
+     */
+    public function serializeDictionary(mixed $runningValue, Field $field, Dict $next, Serializer $serializer): mixed
+    {
+        $runningValue = headtail($runningValue,
+            static function (FormatterStream $runningValue, CollectionItem $item) use ($serializer) {
+                $serializer->serialize($item->value, $runningValue, $item->field);
+                return $runningValue;
+            },
+            function (FormatterStream $runningValue, CollectionItem $item) use ($serializer) {
+                $runningValue->write($this->separator);
+                $serializer->serialize($item->value, $runningValue, $item->field);
+                return $runningValue;
+            }
+        )($next->items);
+
+        $runningValue->write($this->eol);
+
+        return $runningValue;
+    }
+
+    public function serializeObject(mixed $runningValue, Field $field, Dict $next, Serializer $serializer): mixed
+    {
+        return $this->serializeDictionary($runningValue, $field, $next, $serializer);
+    }
+
+    /**
+     * @param FormatterStream $runningValue
+     */
+    public function serializeNull(mixed $runningValue, Field $field, mixed $next): mixed
+    {
+        // For null, write nothing. It will result in an empty space in the row.
+        return $runningValue;
+    }
+}

--- a/src/Formatter/Deformatter.php
+++ b/src/Formatter/Deformatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Crell\Serde\Formatter;
 
+use Crell\Serde\Attributes\ClassSettings;
 use Crell\Serde\Attributes\Field;
 use Crell\Serde\Deserializer;
 use Crell\Serde\SerdeError;
@@ -14,7 +15,12 @@ interface Deformatter
 
     public function rootField(Deserializer $deserializer, string $targetType): Field;
 
-    public function deserializeInitialize(mixed $serialized, Field $rootField): mixed;
+    public function deserializeInitialize(
+        mixed $serialized,
+        ClassSettings $classDef,
+        Field $rootField,
+        Deserializer $deserializer
+    ): mixed;
 
     public function deserializeInt(mixed $decoded, Field $field): int|SerdeError;
 

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -6,6 +6,7 @@ namespace Crell\Serde\Formatter;
 
 use Crell\Serde\Attributes\ClassSettings;
 use Crell\Serde\Attributes\Field;
+use Crell\Serde\Deserializer;
 
 class JsonFormatter implements Formatter, Deformatter, SupportsCollecting
 {
@@ -31,7 +32,12 @@ class JsonFormatter implements Formatter, Deformatter, SupportsCollecting
         return json_encode($runningValue['root'], JSON_THROW_ON_ERROR);
     }
 
-    public function deserializeInitialize(mixed $serialized, Field $rootField): mixed
+    public function deserializeInitialize(
+        mixed $serialized,
+        ClassSettings $classDef,
+        Field $rootField,
+        Deserializer $deserializer
+    ): mixed
     {
         return ['root' => json_decode($serialized ?: '{}', true, 512, JSON_THROW_ON_ERROR)];
     }

--- a/src/Formatter/JsonStreamFormatter.php
+++ b/src/Formatter/JsonStreamFormatter.php
@@ -15,63 +15,11 @@ use function Crell\fp\reduceWithKeys;
 
 class JsonStreamFormatter implements Formatter
 {
+    use StreamFormatter;
+
     public function format(): string
     {
         return 'json-stream';
-    }
-
-    public function rootField(Serializer $serializer, string $type): Field
-    {
-        return Field::create('root', $type);
-    }
-
-    public function serializeInitialize(ClassSettings $classDef, Field $rootField): FormatterStream
-    {
-        return FormatterStream::new(fopen('php://temp/', 'wb'));
-    }
-
-    /**
-     * @param FormatterStream $runningValue
-     */
-    public function serializeFinalize(mixed $runningValue, ClassSettings $classDef): FormatterStream
-    {
-        return $runningValue;
-    }
-
-    /**
-     * @param FormatterStream $runningValue
-     */
-    public function serializeInt(mixed $runningValue, Field $field, int $next): FormatterStream
-    {
-        $runningValue->write((string)$next);
-        return $runningValue;
-    }
-
-    /**
-     * @param FormatterStream $runningValue
-     */
-    public function serializeFloat(mixed $runningValue, Field $field, float $next): FormatterStream
-    {
-        $runningValue->write((string)$next);
-        return $runningValue;
-    }
-
-    /**
-     * @param FormatterStream $runningValue
-     */
-    public function serializeString(mixed $runningValue, Field $field, string $next): FormatterStream
-    {
-        $runningValue->printf('"%s"', $next);
-        return $runningValue;
-    }
-
-    /**
-     * @param FormatterStream $runningValue
-     */
-    public function serializeBool(mixed $runningValue, Field $field, bool $next): FormatterStream
-    {
-        $runningValue->write($next ? 'true' : 'false');
-        return $runningValue;
     }
 
     /**

--- a/src/Formatter/StreamFormatter.php
+++ b/src/Formatter/StreamFormatter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Formatter;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\Serializer;
+
+trait StreamFormatter
+{
+
+    public function rootField(Serializer $serializer, string $type): Field
+    {
+        return Field::create('root', $type);
+    }
+
+    public function serializeInitialize(ClassSettings $classDef, Field $rootField): mixed
+    {
+        return FormatterStream::new(fopen('php://temp/', 'wb'));
+    }
+
+    public function serializeFinalize(mixed $runningValue, ClassSettings $classDef): mixed
+    {
+        return $runningValue;
+    }
+
+    public function serializeInt(mixed $runningValue, Field $field, int $next): mixed
+    {
+        $runningValue->write((string)$next);
+        return $runningValue;
+    }
+
+    public function serializeFloat(mixed $runningValue, Field $field, float $next): mixed
+    {
+        $runningValue->write((string)$next);
+        return $runningValue;
+    }
+
+    public function serializeString(mixed $runningValue, Field $field, string $next): mixed
+    {
+        $runningValue->printf('"%s"', $next);
+        return $runningValue;
+    }
+
+    public function serializeBool(mixed $runningValue, Field $field, bool $next): mixed
+    {
+        $runningValue->write($next ? 'true' : 'false');
+        return $runningValue;
+    }
+}

--- a/src/Formatter/YamlFormatter.php
+++ b/src/Formatter/YamlFormatter.php
@@ -6,6 +6,7 @@ namespace Crell\Serde\Formatter;
 
 use Crell\Serde\Attributes\ClassSettings;
 use Crell\Serde\Attributes\Field;
+use Crell\Serde\Deserializer;
 use Symfony\Component\Yaml\Yaml;
 
 class YamlFormatter implements Formatter, Deformatter, SupportsCollecting
@@ -57,10 +58,17 @@ class YamlFormatter implements Formatter, Deformatter, SupportsCollecting
 
     /**
      * @param mixed $serialized
+     * @param ClassSettings $classDef
      * @param Field $rootField
+     * @param Deserializer $deserializer
      * @return array<string, mixed>
      */
-    public function deserializeInitialize(mixed $serialized, Field $rootField): array
+    public function deserializeInitialize(
+        mixed $serialized,
+        ClassSettings $classDef,
+        Field $rootField,
+        Deserializer $deserializer
+    ): array
     {
         return ['root' => Yaml::parse($serialized ?: '{}', $this->parseFlags)];
     }

--- a/src/PropertyHandler/DictionaryExporter.php
+++ b/src/PropertyHandler/DictionaryExporter.php
@@ -13,6 +13,7 @@ use Crell\Serde\InvalidArrayKeyType;
 use Crell\Serde\KeyType;
 use Crell\Serde\SerdeError;
 use Crell\Serde\Serializer;
+use Crell\Serde\TypeCategory;
 
 class DictionaryExporter implements Exporter, Importer
 {
@@ -25,15 +26,15 @@ class DictionaryExporter implements Exporter, Importer
             return $serializer->formatter->serializeString($runningValue, $field, $typeField->implode($value));
         }
 
-        $dict = $this->arrayToDict($value, $field);
+        $dict = $this->iteratorToDict($value, $field);
 
         return $serializer->formatter->serializeDictionary($runningValue, $field, $dict, $serializer);
     }
 
     /**
-     * @param array<mixed, mixed> $value
+     * @param iterable<mixed, mixed> $value
      */
-    protected function arrayToDict(array $value, Field $field): Dict
+    protected function iteratorToDict(iterable $value, Field $field): Dict
     {
         /** @var DictionaryField|null $typeField */
         $typeField = $field->typeField;
@@ -59,7 +60,8 @@ class DictionaryExporter implements Exporter, Importer
 
     public function canExport(Field $field, mixed $value, string $format): bool
     {
-        return $field->phpType === 'array' && !\array_is_list($value);
+        return ($field->phpType === 'array' && !\array_is_list($value))
+            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof DictionaryField);
     }
 
     public function importValue(Deserializer $deserializer, Field $field, mixed $source): mixed
@@ -82,7 +84,8 @@ class DictionaryExporter implements Exporter, Importer
     {
         $typeField = $field->typeField;
 
-        return $field->phpType === 'array' && ($typeField === null || $typeField instanceof DictionaryField);
+        return ($field->phpType === 'array' && ($typeField === null || $typeField instanceof DictionaryField))
+            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof DictionaryField);
     }
 
 

--- a/src/PropertyHandler/DictionaryExporter.php
+++ b/src/PropertyHandler/DictionaryExporter.php
@@ -61,7 +61,7 @@ class DictionaryExporter implements Exporter, Importer
     public function canExport(Field $field, mixed $value, string $format): bool
     {
         return ($field->phpType === 'array' && !\array_is_list($value))
-            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof DictionaryField);
+            || ($field->typeCategory === TypeCategory::Generator && $field->typeField instanceof DictionaryField);
     }
 
     public function importValue(Deserializer $deserializer, Field $field, mixed $source): mixed
@@ -85,8 +85,6 @@ class DictionaryExporter implements Exporter, Importer
         $typeField = $field->typeField;
 
         return ($field->phpType === 'array' && ($typeField === null || $typeField instanceof DictionaryField))
-            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof DictionaryField);
+            || ($field->typeCategory === TypeCategory::Generator && $field->typeField instanceof DictionaryField);
     }
-
-
 }

--- a/src/PropertyHandler/SequenceExporter.php
+++ b/src/PropertyHandler/SequenceExporter.php
@@ -44,7 +44,7 @@ class SequenceExporter implements Exporter, Importer
     public function canExport(Field $field, mixed $value, string $format): bool
     {
         return ($field->phpType === 'array' && \array_is_list($value))
-            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof SequenceField);
+            || ($field->typeCategory === TypeCategory::Generator && $field->typeField instanceof SequenceField);
     }
 
     public function importValue(Deserializer $deserializer, Field $field, mixed $source): mixed
@@ -69,7 +69,7 @@ class SequenceExporter implements Exporter, Importer
         // This may still catch a dictionary that is unmarked. That is unavoidable.
         // Fortunately it doesn't break in practice because PHP doesn't care.
         return ($field->phpType === 'array' && ($typeField === null || $typeField instanceof SequenceField))
-            || ($field->typeCategory === TypeCategory::Iterable && $field->typeField instanceof SequenceField);
+            || ($field->typeCategory === TypeCategory::Generator && $field->typeField instanceof SequenceField);
     }
 }
 

--- a/src/Serde.php
+++ b/src/Serde.php
@@ -105,8 +105,10 @@ abstract class Serde
             scopes: $scopes,
         );
 
+        $classDef = $this->analyzer->analyze($to, ClassSettings::class, scopes: $scopes);
+
         $rootField = $formatter->rootField($inner, $to);
-        $decoded = $formatter->deserializeInitialize($serialized, $rootField);
+        $decoded = $formatter->deserializeInitialize($serialized, $classDef, $rootField, $inner);
 
         $new = $inner->deserialize($decoded, $rootField);
 

--- a/src/TypeCategory.php
+++ b/src/TypeCategory.php
@@ -15,7 +15,7 @@ enum TypeCategory
     case Scalar;
     case Object;
     case Array;
-    case Iterable;
+    case Generator;
     case UnitEnum;
     case IntEnum;
     case StringEnum;

--- a/src/TypeCategory.php
+++ b/src/TypeCategory.php
@@ -15,6 +15,7 @@ enum TypeCategory
     case Scalar;
     case Object;
     case Array;
+    case Iterable;
     case UnitEnum;
     case IntEnum;
     case StringEnum;

--- a/tests/ArrayBasedFormatterTest.php
+++ b/tests/ArrayBasedFormatterTest.php
@@ -11,6 +11,7 @@ use Crell\Serde\Records\FlatMapNested\NestedA;
 use Crell\Serde\Records\MappedCollected\ThingA;
 use Crell\Serde\Records\MappedCollected\ThingB;
 use Crell\Serde\Records\MappedCollected\ThingC;
+use Crell\Serde\Records\Point;
 use Crell\Serde\Records\Shapes\Circle;
 
 abstract class ArrayBasedFormatterTest extends SerdeTest
@@ -390,6 +391,18 @@ abstract class ArrayBasedFormatterTest extends SerdeTest
             'expectedType' => 'bool',
             'foundType' => 'int',
         ];
+    }
+
+    public function iterable_property_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertEquals([1, 2, 3], $toTest['lazyInts']);
+        self::assertEquals(['a' => 1, 'b' => 2, 'c' => 3], $toTest['lazyIntDict']);
+        self::assertCount(3, $toTest['lazyPoints']);
+        self::assertEquals(['x' => 1, 'y' => 2, 'z' => 3], $toTest['lazyPoints'][0]);
+        self::assertCount(3, $toTest['lazyPointsDict']);
+        self::assertEquals(['x' => 1, 'y' => 2, 'z' => 3], $toTest['lazyPointsDict']['A']);
     }
 
     public function array_of_null_serializes_cleanly_validate(mixed $serialized): void

--- a/tests/ArrayBasedFormatterTest.php
+++ b/tests/ArrayBasedFormatterTest.php
@@ -393,7 +393,7 @@ abstract class ArrayBasedFormatterTest extends SerdeTest
         ];
     }
 
-    public function iterable_property_validate(mixed $serialized): void
+    public function generator_property_is_run_out_validate(mixed $serialized): void
     {
         $toTest = $this->arrayify($serialized);
 

--- a/tests/CsvFormatterTest.php
+++ b/tests/CsvFormatterTest.php
@@ -7,6 +7,7 @@ namespace Crell\Serde;
 use Crell\Serde\Formatter\CsvFormatter;
 use Crell\Serde\Records\CsvRow;
 use Crell\Serde\Records\CsvTable;
+use Crell\Serde\Records\CsvTableLazy;
 use Crell\Serde\Records\Point;
 use Crell\Serde\Records\PointList;
 use PHPUnit\Framework\TestCase;
@@ -46,5 +47,36 @@ class CsvFormatterTest extends TestCase
             ]),
         ];
     }
+
+    /**
+     * @test
+     * @dataProvider csvExamples()
+     */
+    public function lazy_csv_serialize(): void
+    {
+        $s = new SerdeCommon(formatters: [new CsvFormatter()]);
+
+        $rows = static function() {
+            yield new CsvRow('Larry', 100, 500);
+            yield new CsvRow('Curly', 25, 25.25);
+            yield new CsvRow('Moe', 31, 99.9999);
+        };
+
+        $data = new CsvTableLazy($rows());
+
+        $result = $s->serialize($data, format: 'csv');
+
+        // The deserialized version will use an array, not a generator.
+        $expected = new CsvTableLazy([
+            new CsvRow('Larry', 100, 500),
+            new CsvRow('Curly', 25, 25.25),
+            new CsvRow('Moe', 31, 99.9999),
+        ]);
+
+        $deserialized = $s->deserialize($result, from: 'csv', to: CsvTableLazy::class);
+
+        self::assertEquals($expected, $deserialized);
+    }
+
 
 }

--- a/tests/CsvFormatterTest.php
+++ b/tests/CsvFormatterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+use Crell\Serde\Formatter\CsvFormatter;
+use Crell\Serde\Records\CsvRow;
+use Crell\Serde\Records\CsvTable;
+use Crell\Serde\Records\Point;
+use Crell\Serde\Records\PointList;
+use PHPUnit\Framework\TestCase;
+
+class CsvFormatterTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider csvExamples()
+     */
+    public function csv_serialize(object $data): void
+    {
+        $s = new SerdeCommon(formatters: [new CsvFormatter()]);
+
+        $result = $s->serialize($data, format: 'csv');
+
+        $deserialized = $s->deserialize($result, from: 'csv', to: $data::class);
+
+        self::assertEquals($data, $deserialized);
+    }
+
+    public static function csvExamples(): iterable
+    {
+        yield [
+            new PointList([
+                new Point(1, 2, 3),
+                new Point(4, 5, 6),
+                new Point(7, 8, 9),
+            ]),
+        ];
+
+        yield [
+            new CsvTable([
+                new CsvRow('Larry', 100, 500),
+                new CsvRow('Curly', 25, 25.25),
+                new CsvRow('Moe', 31, 99.9999),
+            ]),
+        ];
+    }
+
+}

--- a/tests/CsvStreamFormatterTest.php
+++ b/tests/CsvStreamFormatterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+use Crell\Serde\Formatter\CsvFormatter;
+use Crell\Serde\Formatter\CsvStreamFormatter;
+use Crell\Serde\Formatter\FormatterStream;
+use Crell\Serde\Records\CsvRow;
+use Crell\Serde\Records\CsvTable;
+use Crell\Serde\Records\CsvTableLazy;
+use Crell\Serde\Records\Point;
+use Crell\Serde\Records\PointList;
+use PHPUnit\Framework\TestCase;
+
+class CsvStreamFormatterTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider csvExamples()
+     */
+    public function csv_serialize(object $data, ?object $expected = null): void
+    {
+        $s = new SerdeCommon(formatters: [new CsvStreamFormatter(), new CsvFormatter()]);
+
+        // Use a temp stream as a placeholder.
+        $init = FormatterStream::new(fopen('php://temp/', 'wb'));
+
+        $result = $s->serialize($data, format: 'csv-stream', init: $init);
+
+        fseek($result->stream, 0);
+        $csv = stream_get_contents($result->stream);
+
+        $expected ??= $data;
+
+        $deserialized = $s->deserialize($csv, from: 'csv', to: $data::class);
+
+        self::assertEquals($expected, $deserialized);
+    }
+
+    public static function csvExamples(): iterable
+    {
+        yield [
+            new PointList([
+                new Point(1, 2, 3),
+                new Point(4, 5, 6),
+                new Point(7, 8, 9),
+            ]),
+        ];
+
+        yield [
+            new CsvTable([
+                new CsvRow('Larry', 100, 500),
+                new CsvRow('Curly', 25, 25.25),
+                new CsvRow('Moe', 31, 99.9999),
+            ]),
+        ];
+
+        $rows = static function() {
+            yield new CsvRow('Larry', 100, 500);
+            yield new CsvRow('Curly', 25, 25.25);
+            yield new CsvRow('Moe', 31, 99.9999);
+        };
+
+        yield [
+            'data' => new CsvTableLazy($rows()),
+            'expected' => new CsvTableLazy([
+                new CsvRow('Larry', 100, 500),
+                new CsvRow('Curly', 25, 25.25),
+                new CsvRow('Moe', 31, 99.9999),
+            ]),
+        ];
+    }
+}

--- a/tests/Records/CsvRow.php
+++ b/tests/Records/CsvRow.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+class CsvRow
+{
+    public function __construct(
+        public string $name,
+        public int $age,
+        public float $balance,
+    ) {}
+}

--- a/tests/Records/CsvTable.php
+++ b/tests/Records/CsvTable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+
+class CsvTable
+{
+    /**
+     * @param CsvRow[] $people
+     */
+    public function __construct(
+        #[SequenceField(arrayType: CsvRow::class)]
+        public array $people,
+    ) {}
+
+}

--- a/tests/Records/CsvTableLazy.php
+++ b/tests/Records/CsvTableLazy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+
+class CsvTableLazy
+{
+    /**
+     * @param CsvRow[] $people
+     */
+    public function __construct(
+        #[SequenceField(arrayType: CsvRow::class)]
+        public iterable $people,
+    ) {}
+
+}

--- a/tests/Records/Iterables.php
+++ b/tests/Records/Iterables.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\DictionaryField;
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\KeyType;
+
+class Iterables
+{
+    public function __construct(
+        #[SequenceField]
+        public iterable $lazyInts,
+        #[DictionaryField(keyType: KeyType::String)]
+        public iterable $lazyIntDict,
+        #[SequenceField(arrayType: Point::class)]
+        public iterable $lazyPoints,
+        #[DictionaryField(arrayType: Point::class, keyType: KeyType::String)]
+        public iterable $lazyPointsDict,
+    ) {}
+}

--- a/tests/Records/PointList.php
+++ b/tests/Records/PointList.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+
+class PointList
+{
+    /**
+     * @param Point[] $points
+     */
+    public function __construct(
+        #[SequenceField(arrayType: Point::class)]
+        public array $points,
+    ) {}
+
+}

--- a/tests/Records/TraversableInts.php
+++ b/tests/Records/TraversableInts.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Exception;
+use Traversable;
+
+class TraversableInts implements \IteratorAggregate
+{
+    public function __construct(
+        public int $count,
+    ) {}
+
+    public function getIterator(): Traversable
+    {
+        return (function() {
+            for ($i = 1; $i <= $this->count; ++$i) {
+                yield $i;
+            }
+        })();
+    }
+
+
+}

--- a/tests/Records/TraversablePoints.php
+++ b/tests/Records/TraversablePoints.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Exception;
+use Traversable;
+
+class TraversablePoints implements \IteratorAggregate
+{
+    public function __construct(
+        public int $count,
+        public Point $point,
+    ) {}
+
+    public function getIterator(): Traversable
+    {
+        return (function() {
+            for ($i = 0; $i < $this->count; ++$i) {
+                yield new Point(
+                    $this->point->x + $i,
+                    $this->point->y + $i,
+                    $this->point->z + $i,
+                );
+            }
+        })();
+    }
+
+
+}

--- a/tests/Records/Traversables.php
+++ b/tests/Records/Traversables.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\DictionaryField;
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\KeyType;
+
+class Traversables
+{
+    public function __construct(
+        public TraversableInts $lazyInts,
+        public TraversablePoints $lazyPoints,
+    ) {}
+}

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -65,6 +65,9 @@ use Crell\Serde\Records\Tasks\BigTask;
 use Crell\Serde\Records\Tasks\SmallTask;
 use Crell\Serde\Records\Tasks\Task;
 use Crell\Serde\Records\Tasks\TaskContainer;
+use Crell\Serde\Records\TraversableInts;
+use Crell\Serde\Records\TraversablePoints;
+use Crell\Serde\Records\Traversables;
 use Crell\Serde\Records\Visibility;
 use PHPUnit\Framework\TestCase;
 
@@ -1267,7 +1270,7 @@ abstract class SerdeTest extends TestCase
     /**
      * @test
      */
-    public function iterable_property(): void
+    public function generator_property_is_run_out(): void
     {
         $s = new SerdeCommon(formatters: $this->formatters);
 
@@ -1300,7 +1303,7 @@ abstract class SerdeTest extends TestCase
 
         $serialized = $s->serialize($data, $this->format);
 
-        $this->iterable_property_validate($serialized);
+        $this->generator_property_is_run_out_validate($serialized);
 
         // Deserialization is always to an array, so we
         // need a separate expected object.
@@ -1316,7 +1319,37 @@ abstract class SerdeTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function iterable_property_validate(mixed $serialized): void
+    public function generator_property_is_run_out_validate(mixed $serialized): void
+    {
+
+    }
+
+    /**
+     * @test
+     */
+    public function traversable_object_not_iterated(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $intSeq = new TraversableInts(4);
+
+        $pointSeq = new TraversablePoints(3, new Point(1, 1, 1));
+
+        $data = new Traversables(
+            lazyInts: $intSeq,
+            lazyPoints: $pointSeq,
+        );
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->traversable_object_not_iterated_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: Traversables::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function traversable_object_not_iterated_validate(mixed $serialized): void
     {
 
     }


### PR DESCRIPTION
## Description

As discussed in #9, allow iterable properties to be serialized by turning them into arrays.  Generators will be run-out.  Other Traversable objects will not be.

Also, I included a CSV formatter, because it was straightforward once iterable support was there.  And a CSV Stream formatter, because why not?

## Motivation and context

This means you could have a generator on a property of an object that reads from the DB or some large data stream and outputs one record at a time, and serialize that into `json-stream` or `csv-stream`, meaning both can be of infinite size.  Which is cool. :smile: 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)