### PR TITLE
Allow fields to require a value be provided on deserialiation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ The exact handling of this setting may vary slightly depending on the incoming f
 
 ### `requireValue` (bool, default false)
 
-This key only applies on serialization.  If set to `true`, if the incoming data does not include a value for this field and there is no default specified, a `MissingRequiredValueWhenDeserializing` exception will be thrown.  If not set, and there is no default value, then the property will be left uninitialized.
+This key only applies on deserialization.  If set to `true`, if the incoming data does not include a value for this field and there is no default specified, a `MissingRequiredValueWhenDeserializing` exception will be thrown.  If not set, and there is no default value, then the property will be left uninitialized.
 
 ### `flatten` (bool, default false)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ class Person
 
 Which you do is mostly a matter of preference, although if you are mixing Serde attributes with attributes from other libraries then the namespaced approach is advisable.
 
-There is also a `ClassSettings` attribute that may be placed on classes to be serialized.  At this time it has only one argument, `includeFieldsByDefault`, which defaults to `true`.  If set to false, a property with no `#[Field]` attribute will be ignored.  It is equivalent to setting `exclude: true` on all properties implicitly.
+There is also a `ClassSettings` attribute that may be placed on classes to be serialized.  At this time it has three arguments:
+
+* `includeFieldsByDefault`, which defaults to `true`.  If set to false, a property with no `#[Field]` attribute will be ignored.  It is equivalent to setting `exclude: true` on all properties implicitly.
+* `requireValues`, which defaults to `false`.  If set to true, then when deserializing any field that is not provided in the incoming data will result in an exception.  This may also be turned on or off on a per-field level.  (See `requireValue` below.)  The class-level setting applies to any field that does not specify its behavior.
+* `scopes`, which sets the scope of a given class definition attribute.  See the section on Scopes below.
 
 ### `exclude` (bool, default false)
 
@@ -281,6 +285,8 @@ The exact handling of this setting may vary slightly depending on the incoming f
 ### `requireValue` (bool, default false)
 
 This key only applies on deserialization.  If set to `true`, if the incoming data does not include a value for this field and there is no default specified, a `MissingRequiredValueWhenDeserializing` exception will be thrown.  If not set, and there is no default value, then the property will be left uninitialized.
+
+If a field has a default value, then the default value will always be used for missing data and this setting has no effect.
 
 ### `flatten` (bool, default false)
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ This key only applies on deserialization.  If set to `true`, a type mismatch in 
 
 The exact handling of this setting may vary slightly depending on the incoming format, as some formats handle their own types differently.  (For instance, everything is a string in XML.)
 
+### `requireValue` (bool, default false)
+
+This key only applies on serialization.  If set to `true`, if the incoming data does not include a value for this field and there is no default specified, a `MissingRequiredValueWhenDeserializing` exception will be thrown.  If not set, and there is no default value, then the property will be left uninitialized.
+
 ### `flatten` (bool, default false)
 
 The `flatten` keyword can only be applied on an array or object property.  A property that is "flattened" will have all of its properties injected into the parent directly on serialization, and will have values from the parent "collected" into it on deserialization.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "~8.1",
-        "crell/attributeutils": "~0.8.0",
+        "crell/attributeutils": "~0.8.2",
         "crell/fp": ">= 0.3.3"
     },
     "require-dev": {

--- a/src/Attributes/ClassSettings.php
+++ b/src/Attributes/ClassSettings.php
@@ -32,11 +32,24 @@ class ClassSettings implements FromReflectionClass, ParseProperties, HasSubAttri
     public readonly array $postLoadCallacks;
 
     /**
+     * @param bool $includeFieldsByDefault
+     *   If true, all fields will be included when serializing and deserializing unless
+     *   the individual field opts-out with #[Field(exclude: true)].  If false, all fields
+     *   will be ignored unless they have a #[Field] directive.
      * @param array<string|null> $scopes
+     *   If specified, this ClassSettings entry will be included only when operating in
+     *   the specified scopes.  To also be included in the default "unscoped" case,
+     *   include an array element of `null`, or include a non-scoped copy of the
+     *   Field.
+     * @param bool $requireValues
+     *   If true, all fields will be required when deserializing into this object.
+     *   If false, fields will not be required and unset fields will be left uninitialized.
+     *   this may be overridden on a per-field basis with #[Field(requireValue: true)]
      */
     public function __construct(
         public readonly bool $includeFieldsByDefault = true,
         public readonly array $scopes = [null],
+        public readonly bool $requireValues = false,
     ) {}
 
     public function fromReflection(\ReflectionClass $subject): void

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -114,6 +114,13 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
      *   On deserialization, set to true to require incoming data to be of the
      *   correct type. If false, the system will attempt to cast values to
      *   the correct type.
+     * @param bool $requireValue
+     *   On deserialization, set to true to require incoming data to have a value.
+     *   If it does not, and incoming data is missing a value for this field, and
+     *   no default is set for the property, then an exception will be thrown.  Set
+     *   to false to disable this check, in which case the value may be uninitialized
+     *   after deserialization.  If a property has a default value, this directive
+     *   has no effect.
      * @param array<string|null> $scopes
      *   If specified, this Field entry will be included only when operating in
      *   the specified scopes.  To also be included in the default "unscoped" case,
@@ -129,6 +136,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         public readonly bool $exclude = false,
         public readonly array $alias = [],
         public readonly bool $strict = true,
+        public readonly bool $requireValue = false,
         protected readonly array $scopes = [null],
     ) {
         if ($default) {

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -6,6 +6,7 @@ namespace Crell\Serde\Attributes;
 
 use Attribute;
 use Crell\AttributeUtils\Excludable;
+use Crell\AttributeUtils\Finalizable;
 use Crell\AttributeUtils\FromReflectionProperty;
 use Crell\AttributeUtils\HasSubAttributes;
 use Crell\AttributeUtils\ReadsClass;
@@ -26,7 +27,7 @@ use function Crell\fp\method;
 use function Crell\fp\pipe;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-class Field implements FromReflectionProperty, HasSubAttributes, Excludable, SupportsScopes, ReadsClass
+class Field implements FromReflectionProperty, HasSubAttributes, Excludable, SupportsScopes, ReadsClass, Finalizable
 {
     use Evolvable;
 
@@ -184,8 +185,6 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
                 ?? $constructorDefault
             ;
         }
-
-        $this->finalize();
     }
 
     /**
@@ -216,7 +215,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
 
     }
 
-    protected function finalize(): void
+    public function finalize(): void
     {
         // We cannot compute these until we have the PHP type,
         // but they can still be determined entirely at analysis time

--- a/src/MissingRequiredValueWhenDeserializing.php
+++ b/src/MissingRequiredValueWhenDeserializing.php
@@ -17,7 +17,7 @@ class MissingRequiredValueWhenDeserializing extends \InvalidArgumentException
         $new->class = $class;
         $new->format = $format;
 
-        $new->message = sprintf('No data found for required field "%s" on class %s, deserializing from %s', $name, $class, $format);
+        $new->message = sprintf('No data found for required field "%s" on class %s when deserializing from %s.', $name, $class, $format);
 
         return $new;
     }

--- a/src/MissingRequiredValueWhenDeserializing.php
+++ b/src/MissingRequiredValueWhenDeserializing.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+class MissingRequiredValueWhenDeserializing extends \InvalidArgumentException
+{
+    public readonly string $name;
+    public readonly string $class;
+    public readonly string $format;
+
+    public static function create(string $name, string $class, string $format): self
+    {
+        $new = new self();
+        $new->name = $name;
+        $new->class = $class;
+        $new->format = $format;
+
+        $new->message = sprintf('No data found for required field "%s" on class %s, deserializing from %s', $name, $class, $format);
+
+        return $new;
+    }
+}

--- a/src/PropertyHandler/ObjectImporter.php
+++ b/src/PropertyHandler/ObjectImporter.php
@@ -9,6 +9,7 @@ use Crell\Serde\Attributes\Field;
 use Crell\Serde\Deserializer;
 use Crell\Serde\Formatter\SupportsCollecting;
 use Crell\Serde\InvalidArrayKeyType;
+use Crell\Serde\MissingRequiredValueWhenDeserializing;
 use Crell\Serde\SerdeError;
 use Crell\Serde\TypeCategory;
 
@@ -52,6 +53,7 @@ class ObjectImporter implements Importer
         /** @var Field[] $collectingObjects */
         $collectingObjects = [];
 
+        /** @var Field $propField */
         foreach ($classDef->properties as $propField) {
             $usedNames[] = $propField->serializedName;
             if ($propField->flatten && $propField->typeCategory === TypeCategory::Array) {
@@ -66,6 +68,12 @@ class ObjectImporter implements Importer
                 if ($value === SerdeError::Missing) {
                     if ($propField->shouldUseDefault) {
                         $props[$propField->phpName] = $propField->defaultValue;
+                    } elseif ($propField->requireValue) {
+                        throw MissingRequiredValueWhenDeserializing::create(
+                            $propField->phpName,
+                            $classDef->phpType,
+                            $deserializer->deformatter->format(),
+                        );
                     }
                 } else {
                     $props[$propField->phpName] = $value;

--- a/tests/ArrayFormatterTest.php
+++ b/tests/ArrayFormatterTest.php
@@ -40,6 +40,8 @@ class ArrayFormatterTest extends ArrayBasedFormatterTest
             'stringKey' => ['a' => 'A', 2 => 'B'],
             'intKey' => [5 => 'C', 10 => 'D'],
         ];
+
+        $this->missingOptionalData = ['a' => 'A'];
     }
 
     protected function arrayify(mixed $serialized): array

--- a/tests/JsonFormatterTest.php
+++ b/tests/JsonFormatterTest.php
@@ -28,6 +28,8 @@ class JsonFormatterTest extends ArrayBasedFormatterTest
         $this->invalidDictStringKey = '{"stringKey": {"a": "A", "2": "B"}, "intKey": {"5": "C", "d": "D"}}';
 
         $this->invalidDictIntKey = '{"stringKey": {"a": "A", "2": "B"}, "intKey": {"5": "C", "10": "D"}}';
+
+        $this->missingOptionalData = '{"a": "A"}';
     }
 
     protected function arrayify(mixed $serialized): array

--- a/tests/Records/RequiresFieldValues.php
+++ b/tests/Records/RequiresFieldValues.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+
+#[ClassSettings]
+class RequiresFieldValues
+{
+    public function __construct(
+        #[Field(requireValue: true)]
+        public string $a,
+        // This field has a default, so it being missing should not be an error.
+        #[Field(requireValue: true)]
+        public string $b = 'B',
+    ) {}
+}

--- a/tests/Records/RequiresFieldValuesClass.php
+++ b/tests/Records/RequiresFieldValuesClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+
+#[ClassSettings(requireValues: true)]
+class RequiresFieldValuesClass
+{
+    public function __construct(
+        public string $a,
+        // This field has a default, so it being missing should not be an error.
+        public string $b = 'B',
+    ) {}
+}

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -53,6 +53,7 @@ use Crell\Serde\Records\Pagination\Product;
 use Crell\Serde\Records\Pagination\ProductType;
 use Crell\Serde\Records\Pagination\Results;
 use Crell\Serde\Records\Point;
+use Crell\Serde\Records\RequiresFieldValues;
 use Crell\Serde\Records\RootMap\Type;
 use Crell\Serde\Records\RootMap\TypeB;
 use Crell\Serde\Records\Shapes\Box;
@@ -113,6 +114,13 @@ abstract class SerdeTest extends TestCase
      * @see dictionary_key_int_in_string_throws_in_deserialize()
      */
     protected mixed $invalidDictIntKey;
+
+    /**
+     * Data that is missing a required field for which a default is provided.
+     *
+     * @see missing_required_value_with_default_does_not_throw()
+     */
+    protected mixed $missingOptionalData;
 
     /**
      * @test
@@ -1402,6 +1410,33 @@ abstract class SerdeTest extends TestCase
     public function traversable_object_not_iterated_validate(mixed $serialized): void
     {
 
+    }
+
+    /**
+     * @test
+     */
+    public function missing_required_value_throws(): void
+    {
+        $this->expectException(MissingRequiredValueWhenDeserializing::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $result = $s->deserialize($this->emptyData, $this->format, RequiresFieldValues::class);
+    }
+
+    /**
+     * @test
+     */
+    public function missing_required_value_with_default_does_not_throw(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        /** @var RequiresFieldValues $result */
+        $result = $s->deserialize($this->missingOptionalData, $this->format, RequiresFieldValues::class);
+
+        self::assertEquals('A', $result->a);
+        // This isn't in the incoming data, and is required, but has a default so it's fine.
+        self::assertEquals('B', $result->b);
     }
 
     /**

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -54,6 +54,7 @@ use Crell\Serde\Records\Pagination\ProductType;
 use Crell\Serde\Records\Pagination\Results;
 use Crell\Serde\Records\Point;
 use Crell\Serde\Records\RequiresFieldValues;
+use Crell\Serde\Records\RequiresFieldValuesClass;
 use Crell\Serde\Records\RootMap\Type;
 use Crell\Serde\Records\RootMap\TypeB;
 use Crell\Serde\Records\Shapes\Box;
@@ -1433,6 +1434,33 @@ abstract class SerdeTest extends TestCase
 
         /** @var RequiresFieldValues $result */
         $result = $s->deserialize($this->missingOptionalData, $this->format, RequiresFieldValues::class);
+
+        self::assertEquals('A', $result->a);
+        // This isn't in the incoming data, and is required, but has a default so it's fine.
+        self::assertEquals('B', $result->b);
+    }
+
+    /**
+     * @test
+     */
+    public function missing_required_value_for_class_throws(): void
+    {
+        $this->expectException(MissingRequiredValueWhenDeserializing::class);
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $result = $s->deserialize($this->emptyData, $this->format, RequiresFieldValuesClass::class);
+    }
+
+    /**
+     * @test
+     */
+    public function missing_required_value_for_class_with_default_does_not_throw(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        /** @var RequiresFieldValuesClass $result */
+        $result = $s->deserialize($this->missingOptionalData, $this->format, RequiresFieldValuesClass::class);
 
         self::assertEquals('A', $result->a);
         // This isn't in the incoming data, and is required, but has a default so it's fine.

--- a/tests/YamlFormatterTest.php
+++ b/tests/YamlFormatterTest.php
@@ -37,6 +37,8 @@ class YamlFormatterTest extends ArrayBasedFormatterTest
             'stringKey' => ['a' => 'A', 2 => 'B'],
             'intKey' => [5 => 'C', 10 => 'D'],
         ]);
+
+        $this->missingOptionalData = YAML::dump(['a' => 'A']);
     }
 
     protected function arrayify(mixed $serialized): array


### PR DESCRIPTION
## Description

Adds a new boolean to the `Field` attribute to require the property.  Also a new boolean field to the class to require any property that doesn't specify otherwise.

Given how easy it is to set on a class level, I am going to leave all the defaults at `false`.  It's messing with a lot of other tests otherwise.

I've also decided that if a field is nullable, that means nothing.  If you want a default value of `null` in case of a missing value... set a default value.  That support already exists.

## Motivation and context

Fixes #7 
Fixes #14

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.