### PR TITLE
Allow a flattened object to be null

### DIFF
--- a/src/PropertyHandler/ObjectExporter.php
+++ b/src/PropertyHandler/ObjectExporter.php
@@ -85,7 +85,11 @@ class ObjectExporter implements Exporter
         }
 
         if ($field->typeCategory === TypeCategory::Object) {
-            $subPropReader = (fn (string $prop): mixed => $this->$prop ?? null)->bindTo($value, $value);
+            if ($value === null) {
+                return $dict;
+            }
+            $subPropReader = (fn (string $prop): mixed
+                => array_key_exists($prop, get_object_vars($this)) ? $this->$prop : SerdeError::Missing)->bindTo($value, $value);
             // This really wants to be explicit partial application. :-(
             $c = fn (Dict $dict, Field $prop) => $this->reduceObjectProperty($dict, $prop, $subPropReader, $serializer);
             $properties = $serializer->propertiesFor($value::class);

--- a/tests/Records/FlattenedNullableMain.php
+++ b/tests/Records/FlattenedNullableMain.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\Field;
+
+class FlattenedNullableMain
+{
+    public function __construct(
+        #[Field(flatten: true)]
+        public readonly ?FlattenedNullableNested $nested = null,
+    ) {}
+}

--- a/tests/Records/FlattenedNullableNested.php
+++ b/tests/Records/FlattenedNullableNested.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+class FlattenedNullableNested
+{
+    public function __construct(
+        public readonly ?string $firstName = null,
+    ) {}
+}

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -1566,7 +1566,7 @@ abstract class SerdeTest extends TestCase
 
         $serialized = $s->serialize($data, $this->format);
 
-        $this->null_stuff_validate($serialized);
+        $this->null_properties_are_allowed_validate($serialized);
 
         /** @var NullProps $result */
         $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
@@ -1580,7 +1580,7 @@ abstract class SerdeTest extends TestCase
         self::assertEquals($data, $result);
     }
 
-    public function null_stuff_validate(mixed $serialized): void
+    public function null_properties_are_allowed_validate(mixed $serialized): void
     {
 
     }

--- a/tests/SerdeTest.php
+++ b/tests/SerdeTest.php
@@ -26,6 +26,7 @@ use Crell\Serde\Records\Exclusions;
 use Crell\Serde\Records\FlatMapNested\HostObject;
 use Crell\Serde\Records\FlatMapNested\Item;
 use Crell\Serde\Records\FlatMapNested\NestedA;
+use Crell\Serde\Records\FlattenedNullableMain;
 use Crell\Serde\Records\Flattening;
 use Crell\Serde\Records\ImplodingArrays;
 use Crell\Serde\Records\InvalidFieldType;
@@ -1581,6 +1582,30 @@ abstract class SerdeTest extends TestCase
     }
 
     public function null_properties_are_allowed_validate(mixed $serialized): void
+    {
+
+    }
+
+    /**
+     * @test
+     */
+    public function nullable_properties_flattened(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new FlattenedNullableMain();
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->nullable_properties_flattened_validate($serialized);
+
+        /** @var FlattenedNullableMain $result */
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function nullable_properties_flattened_validate(mixed $serialized): void
     {
 
     }


### PR DESCRIPTION
## Description

Resolves #28.

If a flattened object is nullable and null, previously I was getting an error both on serialization and deserialization.  This fixes that bug.  It also factors some code out of populateObject() that was getting too verbose.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
