### PR TITLE
Allow enforced scalar arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Null is now a legal value for a property to deserialize to.
 - Null values will now be serialized as null, rather than omitted.
 - BC BREAK: The return type of formatter methods have changed to support null as a legal value.
+- `arrayType` on Sequences and Dictionaries can now enforce scalar types.
 - Serde now uses PHPUnit 10.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Serde now uses PHPUnit 10.
 
 ### Fixed
-- There was a bug that prevented default values in attributes to be ignored in some cases.  That has been corrected.
+- There was a bug that caused default values in attributes to be ignored in some cases.  That has been corrected.
 - Flattened nullable objects previously got deserialized into empty objects.  Now they are left as null.
 - Array-based sequences now support non-strict mode, in which they will accept non-sequence arrays but discard the keys.
 - In the default SerdeCommon configuration, dictionaries are now checked first, meaning an un-attributed array will get interpreted as a dictionary, not a sequence.  This is to minimize data loss.  Explicitly specifying a sequence or dictionary attribute is strongly recommended in all cases.

--- a/README.md
+++ b/README.md
@@ -436,9 +436,11 @@ Sometimes that works out, but other times the distinction between the two greatl
 
 #### `arrayType`
 
-On both a `#[SequenceField]` and `#[DictionaryField]`, the `arrayType` argument lets you specify the class that all values in that structure are.  For example, a sequence of integers can easily be serialized to and deserialized from most formats without any additional help.  However, an ordered list of `Product` objects could be serialized, but there's no way to tell then how to deserialize that data back to `Product` objects rather than just a nested associative array (which would also be legal).  The `arrayType` argument solves that issue.
+On both a `#[SequenceField]` and `#[DictionaryField]`, the `arrayType` argument lets you specify the type that all values in that structure are.  For example, a sequence of integers can easily be serialized to and deserialized from most formats without any additional help.  However, an ordered list of `Product` objects could be serialized, but there's no way to tell then how to deserialize that data back to `Product` objects rather than just a nested associative array (which would also be legal).  The `arrayType` argument solves that issue.
 
-If `arrayType` is specified, then all values of that array are assumed to be of that type.  On deserialization, then, Serde will look for nested object-like structures (depending on the specific format), and convert those into the specified object type.
+If `arrayType` is specified, then all values of that array are assumed to be of that type.  It may either be a `class-string` to specify all values are a class, or a value of the `ValueType` enum to indicate one of the four supported scalars.
+
+On deserialization, then, Serde will either validate that all incoming values are of the right scalar type, or look for nested object-like structures (depending on the specific format), and convert those into the specified object type.
 
 For example:
 

--- a/src/Attributes/DictionaryField.php
+++ b/src/Attributes/DictionaryField.php
@@ -8,6 +8,7 @@ use Attribute;
 use Crell\AttributeUtils\SupportsScopes;
 use Crell\Serde\KeyType;
 use Crell\Serde\TypeField;
+use Crell\Serde\ValueType;
 use function Crell\fp\afilter;
 use function Crell\fp\amap;
 use function Crell\fp\amapWithKeys;
@@ -20,8 +21,8 @@ use function Crell\fp\reduce;
 class DictionaryField implements TypeField, SupportsScopes
 {
     /**
-     * @param string|null $arrayType
-     *   Elements in this array are objects of this type.
+     * @param string|ValueType|null $arrayType
+     *   Elements in this array are values of this type.
      * @param string|null $implodeOn
      *   Scalar values of this array should be imploded to a string and exploded on deserialization.
      * @param string|null $joinOn
@@ -32,7 +33,7 @@ class DictionaryField implements TypeField, SupportsScopes
      *   The scopes in which this attribute should apply.
      */
     public function __construct(
-        public readonly ?string $arrayType = null,
+        public readonly string|ValueType|null $arrayType = null,
         public readonly ?KeyType $keyType = null,
         public readonly ?string $implodeOn = null,
         public readonly ?string $joinOn = null,

--- a/src/Attributes/SequenceField.php
+++ b/src/Attributes/SequenceField.php
@@ -7,13 +7,14 @@ namespace Crell\Serde\Attributes;
 use Attribute;
 use Crell\AttributeUtils\SupportsScopes;
 use Crell\Serde\TypeField;
+use Crell\Serde\ValueType;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class SequenceField implements TypeField, SupportsScopes
 {
     /**
-     * @param string|null $arrayType
-     *   Elements in this array are objects of this type.
+     * @param string|ValueType|null $arrayType
+     *   Elements in this array are values of this type.
      * @param string|null $implodeOn
      *   Scalar values of this array should be imploded to a string and exploded on deserialization.
      * @param bool $trim
@@ -22,7 +23,7 @@ class SequenceField implements TypeField, SupportsScopes
      *   The scopes in which this attribute should apply.
      */
     public function __construct(
-        public readonly ?string $arrayType = null,
+        public readonly string|ValueType|null $arrayType = null,
         public readonly ?string $implodeOn = null,
         public readonly bool $trim = true,
         protected readonly array $scopes = [null],

--- a/src/Formatter/CsvFormatter.php
+++ b/src/Formatter/CsvFormatter.php
@@ -85,7 +85,8 @@ class CsvFormatter implements Formatter, Deformatter, SupportsCollecting
         if (! $typeField instanceof SequenceField) {
             throw CsvFormatRequiresExplicitRowType::create($classDef, $rowField);
         }
-        if (!$typeField->arrayType || !class_exists($typeField->arrayType)) {
+        // The row must be an object, to an array type of a primitive doesn't make sense.
+        if (!$typeField->arrayType || !is_string($typeField->arrayType) || !class_exists($typeField->arrayType)) {
             throw CsvFormatRequiresExplicitRowType::create($classDef, $rowField);
         }
 

--- a/src/ValueType.php
+++ b/src/ValueType.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Serde;
+
+use function Crell\fp\all;
+
+enum ValueType
+{
+    case String;
+    case Int;
+    case Float;
+    case Array;
+
+    /**
+     * @param array<mixed> $values
+     */
+    public function assert(array $values): bool
+    {
+        return match ($this) {
+            self::String => all(is_string(...))($values),
+            self::Int => all(is_int(...))($values),
+            self::Float => all(is_float(...))($values),
+            self::Array => all(is_array(...))($values),
+        };
+    }
+}

--- a/tests/Records/ScalarArrays.php
+++ b/tests/Records/ScalarArrays.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\DictionaryField;
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\KeyType;
+use Crell\Serde\ValueType;
+
+class ScalarArrays
+{
+    public function __construct(
+        #[SequenceField(arrayType: ValueType::Int)]
+        public array $ints,
+
+        #[SequenceField(arrayType: ValueType::Float)]
+        public array $floats,
+
+        #[DictionaryField(keyType: KeyType::String, arrayType: ValueType::String)]
+        public array $stringMap,
+
+        #[DictionaryField(keyType: KeyType::String, arrayType: ValueType::Array)]
+        public array $arrayMap,
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -61,6 +61,7 @@ use Crell\Serde\Records\RequiresFieldValues;
 use Crell\Serde\Records\RequiresFieldValuesClass;
 use Crell\Serde\Records\RootMap\Type;
 use Crell\Serde\Records\RootMap\TypeB;
+use Crell\Serde\Records\ScalarArrays;
 use Crell\Serde\Records\SequenceOfStrings;
 use Crell\Serde\Records\Shapes\Box;
 use Crell\Serde\Records\Shapes\Circle;
@@ -1585,5 +1586,59 @@ abstract class SerdeTestCases extends TestCase
         self::assertEquals('B', $result->strict[1]);
         self::assertEquals('A', $result->nonstrict[0]);
         self::assertEquals('B', $result->nonstrict[1]);
+    }
+
+    #[Test]
+    public function arrays_with_valid_scalar_values(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ScalarArrays(
+            ints: [1, 2, 3],
+            floats: [3.14, 2.7],
+            stringMap: ['a' => 'A'],
+            arrayMap: ['a' => [1, 2, 3]],
+        );
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->arrays_with_valid_scalar_values_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function arrays_with_valid_scalar_values_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function arrays_with_invalid_scalar_values(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $this->expectException(TypeMismatch::class);
+
+        // This should serialize fine, but then refuse to deserialize because
+        // of the floats in the int section.
+        $data = new ScalarArrays(
+            ints: [1.1, 2.2, 3],
+            floats: [3.14, 2.7],
+            stringMap: ['a' => 'A'],
+            arrayMap: ['a' => [1, 2, 3]],
+        );
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->arrays_with_valid_scalar_values_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+    }
+
+    public function arrays_with_invalid_scalar_values_validate(mixed $serialized): void
+    {
+
     }
 }


### PR DESCRIPTION
## Description

Add support for requiring that the arrayType of a Seq or Dict be one of four scalar values.  (int, float, string, array.)

## Motivation and context

Resolves #12 
Resolves #17 

## Types of changes

- [X] New feature (non-breaking change which adds functionality)
