### PR TITLE
Fixed small typo in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ class Person
     #[Field(default: 'Hidden')]
     public string $location;
 
-    #[Field[(useDefault: false)]
+    #[Field(useDefault: false)]
     public int $age;
 
     public function __construct(


### PR DESCRIPTION
Small typo in a code example in the README, resulting in syntax error.

## Description

Removed an additional `[` in one code example, where it caused a parse error

## Motivation and context

Confused me for a second or two, since I though I missed new type of syntax getting added to attributes. 
But as far as I (and 3v4l.org) know, its a parse error like this. Fixiting this prevents confusion ;) 

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.  // doe that apply here?
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
