### PR TITLE
Support renaming properties in flattened sub-objects

### DIFF
--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -151,7 +151,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         mixed $default = PropValue::None,
         protected readonly bool $useDefault = true,
         public readonly bool $flatten = false,
-        public readonly ?string $flattenPrefix = null,
+        public readonly string $flattenPrefix = '',
         public readonly bool $exclude = false,
         public readonly array $alias = [],
         public readonly bool $strict = true,

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -121,6 +121,9 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
      *   True to use the default value on deserialization. False to skip setting it entirely.
      * @param bool $flatten
      *   True to flatten an array on serialization and collect into it when deserializing.
+     * @param string $flattenPrefix
+     *   If the field is flattened, this string will be prepended to the name of every field in the sub-value.
+     *   If not flattened, this field is ignored.
      * @param bool $exclude
      *   Set true to exclude this field from serialization entirely.
      * @param string[] $alias
@@ -148,6 +151,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         mixed $default = PropValue::None,
         protected readonly bool $useDefault = true,
         public readonly bool $flatten = false,
+        public readonly ?string $flattenPrefix = null,
         public readonly bool $exclude = false,
         public readonly array $alias = [],
         public readonly bool $strict = true,
@@ -298,11 +302,12 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         ?string $phpType = null,
         array $extraProperties = [],
         TypeField $typeField = null,
+        string $phpName = null,
     ): self
     {
         $new = new self();
         $new->serializedName = $serializedName;
-        $new->phpName = $serializedName;
+        $new->phpName = $phpName ?? $serializedName;
         if ($phpType) {
             $new->phpType = $phpType;
         }

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -454,4 +454,12 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertSame(21, $toTest['age']);
         self::assertSame('me@example.com', $toTest['email']);
     }
+
+    public function multiple_same_class_value_objects_work_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertSame(18, $toTest['min_age']);
+        self::assertSame(65, $toTest['max_age']);
+    }
 }

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -445,4 +445,13 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertIsList($toTest['strict']);
         self::assertIsList($toTest['nonstrict']);
     }
+
+    public function value_objects_with_similar_property_names_work_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertSame('Larry', $toTest['name']);
+        self::assertSame(21, $toTest['age']);
+        self::assertSame('me@example.com', $toTest['email']);
+    }
 }

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -462,4 +462,29 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertSame(18, $toTest['min_age']);
         self::assertSame(65, $toTest['max_age']);
     }
+
+
+    public function multiple_same_class_value_objects_work_when_nested_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertSame(18, $toTest['description']['min_age']);
+        self::assertSame(65, $toTest['description']['max_age']);
+    }
+
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertSame(18, $toTest['min_age']);
+        self::assertSame(65, $toTest['max_age']);
+    }
+
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened_with_prefix_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertSame(18, $toTest['desc_min_age']);
+        self::assertSame(65, $toTest['desc_max_age']);
+    }
 }

--- a/tests/Records/ValueObjects/Age.php
+++ b/tests/Records/ValueObjects/Age.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class Age
+{
+    public function __construct(#[Field(serializedName: 'age')] public int $value)
+    {
+        if ($this->value < 0) {
+            throw new \InvalidArgumentException('Age cannot be negative.');
+        }
+    }
+}

--- a/tests/Records/ValueObjects/Email.php
+++ b/tests/Records/ValueObjects/Email.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class Email
+{
+    public function __construct(#[Field(serializedName: 'email')] public string $value) {}
+}

--- a/tests/Records/ValueObjects/JobDescription.php
+++ b/tests/Records/ValueObjects/JobDescription.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class JobDescription
+{
+    public function __construct(
+        #[Field(flatten: true, flattenPrefix: 'min_')]
+        public Age $minAge,
+        #[Field(flatten: true, flattenPrefix: 'max_')]
+        public Age $maxAge,
+    ) {}
+}

--- a/tests/Records/ValueObjects/JobEntry.php
+++ b/tests/Records/ValueObjects/JobEntry.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Crell\Serde\Records\ValueObjects;
+
+class JobEntry
+{
+    public function __construct(
+        public JobDescription $description,
+    ) {}
+}

--- a/tests/Records/ValueObjects/JobEntryFlattened.php
+++ b/tests/Records/ValueObjects/JobEntryFlattened.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class JobEntryFlattened
+{
+    public function __construct(
+        #[Field(flatten: true)]
+        public JobDescription $description,
+    ) {}
+}

--- a/tests/Records/ValueObjects/JobEntryFlattenedPrefixed.php
+++ b/tests/Records/ValueObjects/JobEntryFlattenedPrefixed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class JobEntryFlattenedPrefixed
+{
+    public function __construct(
+        #[Field(flatten: true, flattenPrefix: 'desc_')]
+        public JobDescription $description,
+    ) {}
+}

--- a/tests/Records/ValueObjects/Person.php
+++ b/tests/Records/ValueObjects/Person.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records\ValueObjects;
+
+use Crell\Serde\Attributes\Field;
+
+class Person
+{
+    public function __construct(
+        public string $name,
+        #[Field(flatten: true)]
+        public Age $age,
+        #[Field(flatten: true)]
+        public Email $email,
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -80,6 +80,9 @@ use Crell\Serde\Records\Traversables;
 use Crell\Serde\Records\ValueObjects\Age;
 use Crell\Serde\Records\ValueObjects\Email;
 use Crell\Serde\Records\ValueObjects\JobDescription;
+use Crell\Serde\Records\ValueObjects\JobEntry;
+use Crell\Serde\Records\ValueObjects\JobEntryFlattened;
+use Crell\Serde\Records\ValueObjects\JobEntryFlattenedPrefixed;
 use Crell\Serde\Records\ValueObjects\Person;
 use Crell\Serde\Records\Visibility;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1684,6 +1687,69 @@ abstract class SerdeTestCases extends TestCase
     }
 
     public function multiple_same_class_value_objects_work_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function multiple_same_class_value_objects_work_when_nested(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new JobEntry(new JobDescription(new Age(18), new Age(65)));
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->multiple_same_class_value_objects_work_when_nested_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function multiple_same_class_value_objects_work_when_nested_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new JobEntryFlattened(new JobDescription(new Age(18), new Age(65)));
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->multiple_same_class_value_objects_work_when_nested_and_flattened_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened_with_prefix(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new JobEntryFlattenedPrefixed(new JobDescription(new Age(18), new Age(65)));
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->multiple_same_class_value_objects_work_when_nested_and_flattened_with_prefix_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function multiple_same_class_value_objects_work_when_nested_and_flattened_with_prefix_validate(mixed $serialized): void
     {
 
     }

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -77,6 +77,9 @@ use Crell\Serde\Records\Tasks\TaskContainer;
 use Crell\Serde\Records\TraversableInts;
 use Crell\Serde\Records\TraversablePoints;
 use Crell\Serde\Records\Traversables;
+use Crell\Serde\Records\ValueObjects\Age;
+use Crell\Serde\Records\ValueObjects\Email;
+use Crell\Serde\Records\ValueObjects\Person;
 use Crell\Serde\Records\Visibility;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -1641,4 +1644,26 @@ abstract class SerdeTestCases extends TestCase
     {
 
     }
+
+    #[Test]
+    public function value_objects_with_similar_property_names_work(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new Person('Larry', new Age(21), new Email('me@example.com'));
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->value_objects_with_similar_property_names_work_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function value_objects_with_similar_property_names_work_validate(mixed $serialized): void
+    {
+
+    }
+
 }

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -79,6 +79,7 @@ use Crell\Serde\Records\TraversablePoints;
 use Crell\Serde\Records\Traversables;
 use Crell\Serde\Records\ValueObjects\Age;
 use Crell\Serde\Records\ValueObjects\Email;
+use Crell\Serde\Records\ValueObjects\JobDescription;
 use Crell\Serde\Records\ValueObjects\Person;
 use Crell\Serde\Records\Visibility;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1662,6 +1663,27 @@ abstract class SerdeTestCases extends TestCase
     }
 
     public function value_objects_with_similar_property_names_work_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function multiple_same_class_value_objects_work(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new JobDescription(new Age(18), new Age(65));
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->multiple_same_class_value_objects_work_validate($serialized);
+
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function multiple_same_class_value_objects_work_validate(mixed $serialized): void
     {
 
     }


### PR DESCRIPTION
## Description

The tracking logic inside `ObjectImporter` was slightly buggy, and didn't support property renaming on objects that are being flattened/collected.  Now it works.

While technically a bug fix, it enables much more convenient value objects so it's also an enhancement.

This also introduces a `flattenPrefix` directive, which lets flattened fields get a prefix defined by the parent class.  That helps to avoid name collisions.

## Motivation and context

Resolves #42.

## How has this been tested?

Additional tests included.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)