### PR TITLE
test: failing test for flattened nullable value object

### DIFF
--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -465,6 +465,14 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertSame('me@example.com', $toTest['email']);
     }
 
+    public function nullable_value_objects_flattened_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertTrue(isset($toTest['order_id']));
+        self::assertNull($toTest['order_id']);
+    }
+
     public function multiple_same_class_value_objects_work_validate(mixed $serialized): void
     {
         $toTest = $this->arrayify($serialized);

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -469,7 +469,7 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
     {
         $toTest = $this->arrayify($serialized);
 
-        self::assertTrue(isset($toTest['order_id']));
+        self::assertArrayHasKey('order_id', $toTest);
         self::assertNull($toTest['order_id']);
     }
 

--- a/tests/Records/FlattenedValueObjectMain.php
+++ b/tests/Records/FlattenedValueObjectMain.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\Field;
+
+class FlattenedValueObjectMain
+{
+    public function __construct(
+        #[Field(flatten: true, flattenPrefix: 'order_')]
+        public readonly ?OrderId $orderId = null,
+    ) {}
+}

--- a/tests/Records/OrderId.php
+++ b/tests/Records/OrderId.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\Field;
+
+class OrderId
+{
+    public function __construct(
+        #[Field(serializedName: 'id')]
+        public readonly int $value,
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -39,6 +39,7 @@ use Crell\Serde\Records\FlatMapNested\HostObject;
 use Crell\Serde\Records\FlatMapNested\Item;
 use Crell\Serde\Records\FlatMapNested\NestedA;
 use Crell\Serde\Records\FlattenedNullableMain;
+use Crell\Serde\Records\FlattenedValueObjectMain;
 use Crell\Serde\Records\Flattening;
 use Crell\Serde\Records\ImplodingArrays;
 use Crell\Serde\Records\InvalidFieldType;
@@ -1291,6 +1292,28 @@ abstract class SerdeTestCases extends TestCase
         $serialized = $s->serialize($data, $this->format);
 
         $this->validateSerialized($serialized, __FUNCTION__);
+
+        /** @var FlattenedNullableMain $result */
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    #[Test]
+    public function nullable_value_objects_flattened(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new FlattenedValueObjectMain(null);
+
+        // Serialisation here hides the issue...
+        // $serialized = $s->serialize($data, $this->format);
+
+        $serialized = match ($this->format) {
+            'array' => ['order_id' => null],
+            'json' => '{"order_id":null}',
+            'yaml' => 'order_id: null',
+        };
 
         /** @var FlattenedNullableMain $result */
         $result = $s->deserialize($serialized, from: $this->format, to: $data::class);

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -1306,19 +1306,19 @@ abstract class SerdeTestCases extends TestCase
 
         $data = new FlattenedValueObjectMain(null);
 
-        // Serialisation here hides the issue...
-        // $serialized = $s->serialize($data, $this->format);
+        $serialized = $s->serialize($data, $this->format);
 
-        $serialized = match ($this->format) {
-            'array' => ['order_id' => null],
-            'json' => '{"order_id":null}',
-            'yaml' => 'order_id: null',
-        };
+        $this->nullable_value_objects_flattened_validate($serialized);
 
         /** @var FlattenedNullableMain $result */
         $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
 
         self::assertEquals($data, $result);
+    }
+
+    public function nullable_value_objects_flattened_validate(mixed $serialized): void
+    {
+
     }
 
     #[Test]


### PR DESCRIPTION
This PR adds a failing test for a scenario that doesn't seem to be covered and I'm currently having issues with. I've had a crack at fixing it but I can't figure it out.

Quite a common pattern in my code is a nullable value object, where the parent is nullable but the value object itself contains a non-nullable value. You'll see an example of this in the test I've written.

I also make use of the flattening stuff to rename the value object to something more relevant while still retaining reusability of the value object itself.

Hopefully this helps maintainers here to identify the issue and point me in the right direction 🙏🏻 