### PR TITLE
Let `json-stream` formatter escape quotes in strings

### DIFF
--- a/src/Formatter/JsonStreamFormatter.php
+++ b/src/Formatter/JsonStreamFormatter.php
@@ -43,6 +43,12 @@ class JsonStreamFormatter implements Formatter
         return $runningValue;
     }
 
+    public function serializeString(mixed $runningValue, Field $field, ?string $next): mixed
+    {
+        $runningValue->printf('"%s"', str_replace('"', '\"', $next));
+        return $runningValue;
+    }
+
     /**
      * @param FormatterStream $runningValue
      */

--- a/src/Formatter/JsonStreamFormatter.php
+++ b/src/Formatter/JsonStreamFormatter.php
@@ -45,7 +45,7 @@ class JsonStreamFormatter implements Formatter
 
     public function serializeString(mixed $runningValue, Field $field, ?string $next): mixed
     {
-        $runningValue->printf('"%s"', str_replace('"', '\"', $next));
+        $runningValue->printf('"%s"', is_string($next) ? str_replace('"', '\"', $next) : null);
         return $runningValue;
     }
 

--- a/src/Formatter/JsonStreamFormatter.php
+++ b/src/Formatter/JsonStreamFormatter.php
@@ -43,6 +43,9 @@ class JsonStreamFormatter implements Formatter
         return $runningValue;
     }
 
+    /**
+     * @param FormatterStream $runningValue
+     */
     public function serializeString(mixed $runningValue, Field $field, ?string $next): mixed
     {
         $runningValue->printf('"%s"', is_string($next) ? str_replace('"', '\"', $next) : null);

--- a/tests/JsonStreamFormatterTest.php
+++ b/tests/JsonStreamFormatterTest.php
@@ -131,7 +131,7 @@ class JsonStreamFormatterTest extends TestCase
         yield AllFieldTypes::class => [
             'data' => new AllFieldTypes(
                 anint: 5,
-                string: 'hello',
+                string: '"hello"',
                 afloat: 3.14,
                 bool: true,
                 dateTimeImmutable: new \DateTimeImmutable('2021-05-01 08:30:45', new \DateTimeZone('America/Chicago')),


### PR DESCRIPTION
## Description

I found that the `json-stream` formatter currently does not escape any quotation marks in strings so that the output won't be well-formed JSON.

For example, this results in invalid JSON being produced:

```php
class Foo { 
  function __construct(public string $foo) {}
}

$serde = new SerdeCommon();
$result = $serde->serialize(new Foo('test " '), format: 'json-stream');
```
The result will be `{"foo":"test " "}`.

I am fixing this by overriding the `serializeString` method to escape quotes.

## Motivation and context

I think the issue is self-explanatory.

## How has this been tested?

I updated one test to include a quotation mark which caused the test to no longer pass.
I then made the test pass again by supplying an implementation for `serializeString` that escapes quotes.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
