### PR TITLE
Allow excluding null fields on serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ This release includes a small *breaking change*.  The deformatter methods all no
 ### Security
 - Nothing
 
+## 1.3.0 - DATE
+
+### Added
+- Null values may now be excluded when serializing. See the `omitNullFields` and `omitIfNull` flags in the README.
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## 1.1.0 - 2024-01-20
 
 The main change in this release is better support for flattening value objects.  See the additional section in the README for more details.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ There is also a `ClassSettings` attribute that may be placed on classes to be se
 * `includeFieldsByDefault`, which defaults to `true`.  If set to false, a property with no `#[Field]` attribute will be ignored.  It is equivalent to setting `exclude: true` on all properties implicitly.
 * `requireValues`, which defaults to `false`.  If set to true, then when deserializing any field that is not provided in the incoming data will result in an exception.  This may also be turned on or off on a per-field level.  (See `requireValue` below.)  The class-level setting applies to any field that does not specify its behavior.
 * `renameWith`.  If set, the specified renaming strategy will be used for all properties of the class, unless a property specifies its own.  (See `renameWith` below.)  The class-level setting applies to any field that does not specify its behavior.
+* `omitNullFields`, which defaults to false.  If set to true, any property on the class that is null will be omitted when serializing. It has on effect on deserialization.  This may also be turned on or off on a per-field level.  (See `omitIfNull` below.)
 * `scopes`, which sets the scope of a given class definition attribute.  See the section on Scopes below.
 
 ### `exclude` (bool, default false)
@@ -239,6 +240,10 @@ All three of the following JSON strings would be read into an identical object:
 ```
 
 This is mainly useful when an API key has changed, and legacy incoming data may still have an old key name.
+
+### `omitIfNull` (bool, default false)
+
+This key only applies on serialization.  If set to true, and the value of this property is null when an object is serialized, it will be omitted from the output entirely.  If false, a `null` will be written to the output, however that looks for the particular format.
 
 ### `useDefault` (bool, default true)
 

--- a/src/Attributes/ClassSettings.php
+++ b/src/Attributes/ClassSettings.php
@@ -46,12 +46,17 @@ class ClassSettings implements FromReflectionClass, ParseProperties, HasSubAttri
      *   If true, all fields will be required when deserializing into this object.
      *   If false, fields will not be required and unset fields will be left uninitialized.
      *   this may be overridden on a per-field basis with #[Field(requireValue: true)]
-     */
+     * @param bool $omitNullFields
+     *    When serializing, if a property is set to null, exclude it from the output
+     *    entirely.  Default false, meaning a "null" will be written to the output format.
+     *    This may be overridden on a per-field basis.
+    */
     public function __construct(
         public readonly bool $includeFieldsByDefault = true,
         public readonly array $scopes = [null],
         public readonly bool $requireValues = false,
         public readonly ?RenamingStrategy $renameWith = null,
+        public readonly bool $omitNullFields = false,
     ) {}
 
     public function fromReflection(\ReflectionClass $subject): void

--- a/src/PropertyHandler/ObjectExporter.php
+++ b/src/PropertyHandler/ObjectExporter.php
@@ -73,6 +73,10 @@ class ObjectExporter implements Exporter
             return $dict;
         }
 
+        if ($field->omitIfNull && is_null($value)) {
+            return $dict;
+        }
+
         if (!$field->flatten) {
             return $dict->add(new CollectionItem(field: $field, value: $value));
         }

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -498,4 +498,20 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertSame(65, $toTest['desc_max_age']);
     }
 
+    public function null_properties_may_be_excluded_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertEquals('A', $toTest['name']);
+        self::assertArrayNotHasKey('age', $toTest);
+    }
+
+    public function null_properties_may_be_excluded_class_level_validate(mixed $serialized): void
+    {
+        $toTest = $this->arrayify($serialized);
+
+        self::assertEquals('A', $toTest['name']);
+        self::assertArrayNotHasKey('age', $toTest);
+    }
+
 }

--- a/tests/Records/ExcludeNullFields.php
+++ b/tests/Records/ExcludeNullFields.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\Field;
+
+class ExcludeNullFields
+{
+    public function __construct(
+        public string $name,
+        #[Field(omitIfNull: true)]
+        public ?int $age = null,
+    ) {}
+}

--- a/tests/Records/ExcludeNullFieldsClass.php
+++ b/tests/Records/ExcludeNullFieldsClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+
+#[ClassSettings(omitNullFields: true)]
+class ExcludeNullFieldsClass
+{
+    public function __construct(
+        public string $name,
+        public ?int $age = null,
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -31,6 +31,8 @@ use Crell\Serde\Records\Drupal\Node;
 use Crell\Serde\Records\Drupal\StringItem;
 use Crell\Serde\Records\Drupal\TextItem;
 use Crell\Serde\Records\EmptyData;
+use Crell\Serde\Records\ExcludeNullFields;
+use Crell\Serde\Records\ExcludeNullFieldsClass;
 use Crell\Serde\Records\Exclusions;
 use Crell\Serde\Records\ExplicitDefaults;
 use Crell\Serde\Records\FlatMapNested\HostObject;
@@ -1618,6 +1620,50 @@ abstract class SerdeTestCases extends TestCase
     }
 
     public function nullable_properties_flattened_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function null_properties_may_be_excluded(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ExcludeNullFields('A');
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->null_properties_may_be_excluded_validate($serialized);
+
+        /** @var ExcludeNullFields $result */
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function null_properties_may_be_excluded_validate(mixed $serialized): void
+    {
+
+    }
+
+    #[Test]
+    public function null_properties_may_be_excluded_class_level(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $data = new ExcludeNullFieldsClass('A');
+
+        $serialized = $s->serialize($data, $this->format);
+
+        $this->null_properties_may_be_excluded_class_level_validate($serialized);
+
+        /** @var ExcludeNullFields $result */
+        $result = $s->deserialize($serialized, from: $this->format, to: $data::class);
+
+        self::assertEquals($data, $result);
+    }
+
+    public function null_properties_may_be_excluded_class_level_validate(mixed $serialized): void
     {
 
     }


### PR DESCRIPTION
## Description

Adds a new `omitIfNull` flag for fields, and a default-setting `omitNullFields` class-level flag.

## Motivation and context

Resolves #60.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
