### PR TITLE
Escape strings in JSON stream formatter.

### DIFF
--- a/src/Formatter/JsonStreamFormatter.php
+++ b/src/Formatter/JsonStreamFormatter.php
@@ -25,6 +25,15 @@ class JsonStreamFormatter implements Formatter
     /**
      * @param FormatterStream $runningValue
      */
+    public function serializeString(mixed $runningValue, Field $field, ?string $next): mixed
+    {
+        $runningValue->printf('"%s"', is_string($next) ? str_replace('"', '\"', $next) : null);
+        return $runningValue;
+    }
+
+    /**
+     * @param FormatterStream $runningValue
+     */
     public function serializeSequence(mixed $runningValue, Field $field, Sequence $next, Serializer $serializer): FormatterStream
     {
         $runningValue->write('[');

--- a/tests/JsonStreamFormatterTest.php
+++ b/tests/JsonStreamFormatterTest.php
@@ -154,6 +154,12 @@ class JsonStreamFormatterTest extends TestCase
             )
         ];
 
+        yield AllFieldTypes::class . ' with JSON-type characters' => [
+            'data' => new AllFieldTypes(
+                string: '{ "with quotes", and { characters ".',
+            )
+        ];
+
         yield NullArrays::class => [
             'data' => new NullArrays(),
         ];


### PR DESCRIPTION
## Description

Re-run of #59, as the author there has gone AWOL.

Resolves #59 

## Motivation and context

'tis a bug.