### PR TITLE
Allow weak mode to apply to values in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 - Null values may now be excluded when serializing. See the `omitNullFields` and `omitIfNull` flags in the README.
 - We now require AttributeUtils 1.2, which lets us use closures rather than method name strings for subAttribute callbacks. (Internal improvement.)
+- When `strict` is false on a sequence or dictionary, numeric strings will get cast to an int or float as appropriate.  Previously the list values were processed in strict mode regardless of what the field was set to.
 
 ### Deprecated
 - Nothing

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ This key only applies on deserialization.  If set to `true`, a type mismatch in 
 
 For sequence fields, `strict` set to `true` will reject a non-sequence value.  (It must pass an `array_is_list()` check.)  If `strict` is `false`, any array-ish value will be accepted but passed through `array_values()` to discard any keys and reindex it.
 
+Additionally, in non-`strict` mode, numeric strings in the incoming array will be cast to ints or floats as appropriate in both sequence fields and dictionary fields.  In `strict` mode, numeric strings will still be rejected.
+
 The exact handling of this setting may vary slightly depending on the incoming format, as some formats handle their own types differently.  (For instance, everything is a string in XML.)
 
 ### `requireValue` (bool, default false)

--- a/src/Formatter/ArrayBasedDeformatter.php
+++ b/src/Formatter/ArrayBasedDeformatter.php
@@ -144,6 +144,9 @@ trait ArrayBasedDeformatter
         // @phpstan-ignore-next-line
         $class = $field?->typeField?->arrayType ?? '';
         if ($class instanceof ValueType) {
+            if (!$field->strict) {
+                $data = $class->coerce($data);
+            }
             if ($class->assert($data)) {
                 return $data;
             } else {
@@ -179,6 +182,9 @@ trait ArrayBasedDeformatter
         // @phpstan-ignore-next-line
         $class = $field?->typeField?->arrayType ?? '';
         if ($class instanceof ValueType) {
+            if (!$field->strict) {
+                $data = $class->coerce($data);
+            }
             if ($class->assert($data)) {
                 return $data;
             } else {

--- a/src/ValueType.php
+++ b/src/ValueType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Crell\Serde;
 
 use function Crell\fp\all;
+use function Crell\fp\amap;
 
 enum ValueType
 {
@@ -22,6 +23,20 @@ enum ValueType
             self::Int => all(is_int(...))($values),
             self::Float => all(is_float(...))($values),
             self::Array => all(is_array(...))($values),
+        };
+    }
+
+    /**
+     * @param array<mixed> $values
+     * @return array<mixed>
+     */
+    public function coerce(array $values): array
+    {
+        return match ($this) {
+            self::String => $values,
+            self::Int => amap(intval(...))($values),
+            self::Float => amap(floatval(...))($values),
+            self::Array => $values,
         };
     }
 }

--- a/tests/ArrayFormatterTest.php
+++ b/tests/ArrayFormatterTest.php
@@ -53,6 +53,11 @@ class ArrayFormatterTest extends ArrayBasedFormatterTestCases
             'strict' => ['A', 'B'],
             'nonstrict' => ['a' => 'A', 'b' => 'B'],
         ];
+
+        $this->weakModeLists = [
+            'seq' => [1, '2', 3],
+            'dict' => ['a' => 1, 'b' => '2'],
+        ];
     }
 
     protected function arrayify(mixed $serialized): array

--- a/tests/JsonFormatterTest.php
+++ b/tests/JsonFormatterTest.php
@@ -40,6 +40,11 @@ class JsonFormatterTest extends ArrayBasedFormatterTestCases
             'strict' => ['A', 'B'],
             'nonstrict' => ['a' => 'A', 'b' => 'B'],
         ]);
+
+        $this->weakModeLists = json_encode([
+            'seq' => [1, '2', 3],
+            'dict' => ['a' => 1, 'b' => '2'],
+        ]);
     }
 
     protected function arrayify(mixed $serialized): array

--- a/tests/Records/WeakLists.php
+++ b/tests/Records/WeakLists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\DictionaryField;
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\Attributes\SequenceField;
+use Crell\Serde\KeyType;
+use Crell\Serde\ValueType;
+
+class WeakLists
+{
+    public function __construct(
+        #[Field(strict: false), SequenceField(ValueType::Int)]
+        public array $seq,
+        #[Field(strict: false), DictionaryField(arrayType: ValueType::Int, keyType: KeyType::String)]
+        public array $dict,
+    ) {}
+}

--- a/tests/YamlFormatterTest.php
+++ b/tests/YamlFormatterTest.php
@@ -49,6 +49,11 @@ class YamlFormatterTest extends ArrayBasedFormatterTestCases
             'strict' => ['A', 'B'],
             'nonstrict' => ['a' => 'A', 'b' => 'B'],
         ]);
+
+        $this->weakModeLists = YAML::dump([
+            'seq' => [1, '2', 3],
+            'dict' => ['a' => 1, 'b' => '2'],
+        ]);
     }
 
     protected function arrayify(mixed $serialized): array


### PR DESCRIPTION
## Description

In non-strict mode, numeric strings should get cast to int or float as appropriate.

## Motivation and context

Found this bug (I'd say it's a bug) while working on #69.

## How has this been tested?

New tests included

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
