### PR TITLE
Only use a constructor param default value if it's a promoted property.

### DIFF
--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -240,7 +240,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
 
         $param = $params[$declaringClass->getName()][$subject->getName()] ?? null;
 
-        return $param?->isDefaultValueAvailable()
+        return $param?->isDefaultValueAvailable() && $param->isPromoted()
             ? $param->getDefaultValue()
             : PropValue::None;
     }

--- a/tests/Records/NonPromotedDefault.php
+++ b/tests/Records/NonPromotedDefault.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+class NonPromotedDefault
+{
+    public string $value;
+
+    public function __construct(
+        string|array $value = []
+    ) {
+        $this->value = is_array($value) ? implode(',', $value) : $value;
+    }
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -57,6 +57,7 @@ use Crell\Serde\Records\MultipleScopesDefaultTrue;
 use Crell\Serde\Records\NativeSerUn;
 use Crell\Serde\Records\NestedFlattenObject;
 use Crell\Serde\Records\NestedObject;
+use Crell\Serde\Records\NonPromotedDefault;
 use Crell\Serde\Records\NullArrays;
 use Crell\Serde\Records\NullProps;
 use Crell\Serde\Records\OptionalPoint;
@@ -449,6 +450,18 @@ abstract class SerdeTestCases extends TestCase
         $result = $s->deserialize($serialized, from: $this->format, to: AllFieldTypes::class);
 
         self::assertEquals(new AllFieldTypes(), $result);
+    }
+
+    #[Test]
+    public function matching_constructor_param_only_uses_default_if_promoted(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $serialized = $this->emptyData;
+
+        $result = $s->deserialize($serialized, from: $this->format, to: NonPromotedDefault::class);
+
+        self::assertEquals('not set', $result->value ?? 'not set');
     }
 
     #[Test, Group('typemap')]


### PR DESCRIPTION
## Description

Resolves #72
