### PR TITLE
Add test for JSON deserialization of a list into PointList object, ve…

### DIFF
--- a/tests/JsonFormatterTest.php
+++ b/tests/JsonFormatterTest.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Crell\Serde;
 
-use Crell\Serde\Formatter\CsvFormatter;
 use Crell\Serde\Formatter\JsonFormatter;
-use Crell\Serde\Records\Point;
 use Crell\Serde\Records\PointList;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class JsonFormatterTest extends ArrayBasedFormatterTestCases

--- a/tests/JsonFormatterTest.php
+++ b/tests/JsonFormatterTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Crell\Serde;
 
+use Crell\Serde\Formatter\CsvFormatter;
 use Crell\Serde\Formatter\JsonFormatter;
+use Crell\Serde\Records\Point;
+use Crell\Serde\Records\PointList;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 class JsonFormatterTest extends ArrayBasedFormatterTestCases
 {
@@ -85,5 +90,18 @@ class JsonFormatterTest extends ArrayBasedFormatterTestCases
             $v['serialized'] = json_encode($v['serialized'], JSON_THROW_ON_ERROR);
             yield $k => $v;
         }
+    }
+
+    #[Test]
+    public function json_deserialize_list(): void
+    {
+        $points = '[{"x":1,"y":2,"z":3},{"x":4,"y":5,"z":6},{"x":7,"y":8,"z":9}]';
+
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $deserialized = $s->deserialize($points, from: 'json', to: PointList::class);
+
+        self::assertInstanceOf(PointList::class, $deserialized);
+        self::assertCount(3, $deserialized->points);
     }
 }


### PR DESCRIPTION
This is a test to demonstrate desired behaviour of list deserialization. Such JSON array lists are common in the REST world and it's unclear how to deserialize them.

The only way to do it now it to json_decode the response, then iterate over it, json_encode each element and deserialize them individually. sure there is a better way? 