### PR TITLE
add more type tags

### DIFF
--- a/src/Attributes/Binary.php
+++ b/src/Attributes/Binary.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Binary implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return true;
+    }
+}

--- a/src/Attributes/Fixed32.php
+++ b/src/Attributes/Fixed32.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Fixed32 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Fixed64.php
+++ b/src/Attributes/Fixed64.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Fixed64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Float32.php
+++ b/src/Attributes/Float32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Float32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'float';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Float64.php
+++ b/src/Attributes/Float64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Float64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'float' || $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Int32.php
+++ b/src/Attributes/Int32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Int32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Int64.php
+++ b/src/Attributes/Int64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Int64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed32.php
+++ b/src/Attributes/SFixed32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class SFixed32 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed64.php
+++ b/src/Attributes/SFixed64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class SFixed64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed64.php
+++ b/src/Attributes/SFixed64.php
@@ -21,7 +21,7 @@ class SFixed64 implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'int';
+        return $type === 'int' || $type === 'string';
     }
 
     public function validate(mixed $value): bool

--- a/src/Attributes/SInt32.php
+++ b/src/Attributes/SInt32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class SInt32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SInt64.php
+++ b/src/Attributes/SInt64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class SInt64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SInt64.php
+++ b/src/Attributes/SInt64.php
@@ -21,7 +21,7 @@ class SInt64 implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'int';
+        return $type === 'int' || $type === 'string';
     }
 
     public function validate(mixed $value): bool

--- a/src/Attributes/UInt32.php
+++ b/src/Attributes/UInt32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class UInt32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int' || $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/UInt64.php
+++ b/src/Attributes/UInt64.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class UInt64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To support something like protobuf, Serde requires more type tags than PHP currently has support for. This adds multiple new type tags that currently do nothing:

- Binary: marks a string as "binary" vs. utf8 (or whatever encoding it is).
- Fixed32: marks an integer or string as a fixed-width unsigned 32-bit integer. This can be represented fully on a 64-bit system, but not on a 32-bit system.
- Fixed64: marks an integer or string as a fixed-width unsigned 64-bit integer. This can be represented partially on a 64-bit system, but not fully.
- Float32: marks a float as a 32-bit float.
- Float64: marks a string or float as a 64-bit float. A string representation may be required on 32-bit systems.
- Int32: marks an integer as a 32-bit integer.
- Int64: marks an integer or string as a 64-bit integer. A string representation may be required on 32-bit systems.
- SFixed32: marks an integer as a fixed 32-bit signed integer. For binary representations, this will always be 32-bits, including padding.
- SFixed64: marks an integer as a fixed 64-bit signed integer. For binary representations, this will always be 64-bits, even if it could fit in a 32-bit number.
- SInt32: marks an integer as a signed 32-bit integer.
- SInt64: marks an integer or string as a signed 64-bit integer.
- UInt32: marks an integer or string as an unsigned 32-bit integer.
- UInt64: marks an integer or string as an unsigned 64-bit integer.

## Motivation and context

These type-tags are required for protobuf support to work correctly. There are various differences in encoding for each of these types in protobuf formats. (for example, SInt's are encoded using a zig-zag encoding for more space-efficient representation).

Additionally, other formatters could make use of this. For example, Yaml/JSON could base64 encode strings marked `Binary`. For string-numbers, it can pass through the string representation as a number instead of encoding a string.

## How has this been tested?

These type tags currently have no effect on the output generated. Additional behaviour will come in a followup PR.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
