### PR TITLE
Protobuf Formatter

### DIFF
--- a/src/Attributes/Binary.php
+++ b/src/Attributes/Binary.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Binary implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return true;
+    }
+}

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -151,6 +151,8 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
      *   the specified scopes.  To also be included in the default "unscoped" case,
      *   include an array element of `null`, or include a non-scoped copy of the
      *   Field.
+     * @param int|null $fieldNum
+     *    Some formatters (such as protobuf) allow specifying the serialized order of data.
      */
     public function __construct(
         ?string $serializedName = null,
@@ -165,6 +167,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         ?bool $requireValue = null,
         ?bool $omitIfNull = null,
         protected readonly array $scopes = [null],
+        public readonly int|null $fieldNum = null,
     ) {
         if ($default !== PropValue::None) {
             $this->defaultValue = $default;

--- a/src/Attributes/Fixed32.php
+++ b/src/Attributes/Fixed32.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Fixed32 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Fixed64.php
+++ b/src/Attributes/Fixed64.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Fixed64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Float32.php
+++ b/src/Attributes/Float32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Float32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'float';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Float64.php
+++ b/src/Attributes/Float64.php
@@ -21,7 +21,7 @@ class Float64 implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'float' || $type === 'string';
+        return $type === 'float';
     }
 
     public function validate(mixed $value): bool

--- a/src/Attributes/Float64.php
+++ b/src/Attributes/Float64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Float64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'float' || $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Int32.php
+++ b/src/Attributes/Int32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Int32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/Int64.php
+++ b/src/Attributes/Int64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Int64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed32.php
+++ b/src/Attributes/SFixed32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class SFixed32 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed64.php
+++ b/src/Attributes/SFixed64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Attribute;
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class SFixed64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SFixed64.php
+++ b/src/Attributes/SFixed64.php
@@ -21,7 +21,7 @@ class SFixed64 implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'int';
+        return $type === 'int' || $type === 'string';
     }
 
     public function validate(mixed $value): bool

--- a/src/Attributes/SInt32.php
+++ b/src/Attributes/SInt32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class SInt32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SInt64.php
+++ b/src/Attributes/SInt64.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class SInt64 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/SInt64.php
+++ b/src/Attributes/SInt64.php
@@ -21,7 +21,7 @@ class SInt64 implements TypeField, SupportsScopes
 
     public function acceptsType(string $type): bool
     {
-        return $type === 'int';
+        return $type === 'int' || $type === 'string';
     }
 
     public function validate(mixed $value): bool

--- a/src/Attributes/UInt32.php
+++ b/src/Attributes/UInt32.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class UInt32 implements TypeField, SupportsScopes
+{
+
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'int' || $type === 'string';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+}

--- a/src/Attributes/UInt64.php
+++ b/src/Attributes/UInt64.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class UInt64 implements TypeField, SupportsScopes
+{
+    /**
+     * @param array<string|null> $scopes
+     */
+    public function __construct(protected readonly array $scopes = [null]) {}
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'string' || $type === 'int';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return is_numeric($value);
+    }
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+}

--- a/src/Formatter/Protobuf/ProtoWireType.php
+++ b/src/Formatter/Protobuf/ProtoWireType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Crell\Serde\Formatter\Protobuf;
+
+enum ProtoWireType: int {
+    case VarInt = 0;
+    case Double = 1;
+    case LengthDelimited = 2;
+    // 3, 4 deprecated; not supported
+    case Single = 5;
+
+    public function tag(int $fieldNum): int {
+        $fieldNum = $fieldNum << 3;
+        $tag = $this->value;
+        return $fieldNum | $tag;
+    }
+}

--- a/src/Formatter/Protobuf/RunningValue.php
+++ b/src/Formatter/Protobuf/RunningValue.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Crell\Serde\Formatter\Protobuf;
+
+class RunningValue
+{
+    /**
+     * @var array<int>
+     */
+    private array $fieldNumLocked = [];
+
+    public function __construct(
+        public string $bytes = '',
+        public int $cursorOffset = 0,
+        public int $lastFieldNum = 0,
+    ) {}
+
+    public function lockFieldNumber(): void {
+        $this->fieldNumLocked[] = $this->lastFieldNum;
+    }
+
+    public function unlockFieldNumber(): void {
+        $this->lastFieldNum = array_pop($this->fieldNumLocked) ?? throw new \LogicException('too many unlocks');
+    }
+
+    public function appendTag(ProtoWireType $type, int|null $fieldNum): void
+    {
+        $fieldNum ??= ($this->fieldNumLocked ? $this->lastFieldNum : ++$this->lastFieldNum);
+        $this->lastFieldNum = $fieldNum;
+
+        $tag = $type->tag($fieldNum);
+        $this->appendVarInt($tag);
+    }
+
+    public function appendVarInt(int $value): void
+    {
+        $bytes = '';
+        while ($value > 0x7f) {
+            $bytes .= chr(($value & 0x7f) | 0x80);
+            $value >>= 7;
+        }
+        $bytes .= chr($value & 0x7f);
+        $this->bytes .= $bytes;
+        $this->cursorOffset += strlen($bytes);
+    }
+
+    public function skipTag(): void
+    {
+        $this->lastFieldNum = $this->lastFieldNum + 1;
+    }
+
+    public function appendBytes(string $bytes): void
+    {
+        $this->bytes .= $bytes;
+        $this->cursorOffset += strlen($bytes);
+    }
+
+    public function decodeVarInt(): int
+    {
+        $result = 0;
+        $shift = 0;
+        $len = strlen($this->bytes);
+        while ($this->cursorOffset < $len) {
+            $byte = ord($this->bytes[$this->cursorOffset++]);
+            $result |= (($byte & 0x7f) << $shift);
+            if (($byte & 0x80) === 0) {
+                return $result;
+            }
+            $shift += 7;
+            if ($shift >= 64) {
+                throw new \RuntimeException("Varint is too large; possibly corrupted data");
+            }
+        }
+
+        throw new \RuntimeException("Unexpected end of data while parsing varint");
+    }
+}

--- a/src/Formatter/ProtobufFormatter.php
+++ b/src/Formatter/ProtobufFormatter.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Crell\Serde\Formatter;
+
+use Crell\Serde\Attributes\Binary;
+use Crell\Serde\Attributes\ClassSettings;
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\Attributes\Fixed32;
+use Crell\Serde\Attributes\Fixed64;
+use Crell\Serde\Attributes\Float32;
+use Crell\Serde\Attributes\Float64;
+use Crell\Serde\Attributes\Int32;
+use Crell\Serde\Attributes\Int64;
+use Crell\Serde\Attributes\SFixed32;
+use Crell\Serde\Attributes\SFixed64;
+use Crell\Serde\Attributes\SInt32;
+use Crell\Serde\Attributes\SInt64;
+use Crell\Serde\Attributes\UInt32;
+use Crell\Serde\Attributes\UInt64;
+use Crell\Serde\Dict;
+use Crell\Serde\Formatter\Protobuf\ProtoWireType;
+use Crell\Serde\Formatter\Protobuf\RunningValue;
+use Crell\Serde\Sequence;
+use Crell\Serde\Serializer;
+
+class ProtobufFormatter implements Formatter
+{
+    private const FULL32 = 0xffffffff;
+    private const INT32_MAX = '4294967296';
+    private static Field|null $root = null;
+
+    public function format(): string
+    {
+        return 'protobuf';
+    }
+
+    public function rootField(Serializer $serializer, string $type): Field
+    {
+        return self::$root ??= Field::create('root', $type);
+    }
+
+    public function serializeInitialize(ClassSettings $classDef, Field $rootField): RunningValue
+    {
+        return new RunningValue();
+    }
+
+    public function serializeFinalize(mixed $runningValue, ClassSettings $classDef): string
+    {
+        assert($runningValue instanceof RunningValue);
+        return $runningValue->bytes;
+    }
+
+    public function serializeFloat(mixed $runningValue, Field $field, ?float $next): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+        if ($next === null) {
+            $runningValue->skipTag();
+            return $runningValue;
+        }
+
+        $typeField = $field->typeField === null ? null : get_class($field->typeField);
+        switch ($typeField) {
+            case null:
+            case Float64::class:
+                $bytes = pack('e', $next);
+                $runningValue->appendTag(ProtoWireType::Double, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+            case Float32::class:
+                $bytes = pack('g', $next);
+                $runningValue->appendTag(ProtoWireType::Single, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+        }
+
+        return $runningValue;
+    }
+
+    public function serializeString(mixed $runningValue, Field $field, ?string $next): mixed
+    {
+        assert($runningValue instanceof RunningValue);
+
+        if ($next === null) {
+            $runningValue->skipTag();
+            return $runningValue;
+        }
+
+        $typeField = $field->typeField === null ? null : get_class($field->typeField);
+        switch ($typeField) {
+            case null:
+                if(!mb_check_encoding($next, 'UTF-8')) {
+                    throw new \RuntimeException('Cannot encode non-utf8 string as protobuf');
+                }
+                // fall through on purpose.
+            case Binary::class:
+                $runningValue->appendTag(ProtoWireType::LengthDelimited, $field->fieldNum);
+                $runningValue->appendVarInt(strlen($next));
+                $runningValue->appendBytes($next);
+                break;
+            case Fixed32::class:
+                if (extension_loaded('bcmath')) {
+                    $bytes = bcmod($next, self::INT32_MAX);
+                } else {
+                    if (extension_loaded('gmp')) {
+                        $bytes = gmp_mod($next, self::INT32_MAX);
+                        $bytes = gmp_intval($bytes);
+                    } else {
+                        throw new \RuntimeException('GMP or bcmath extension required for string maths');
+                    }
+                }
+                $bytes = (int)$bytes;
+                return $this->serializeInt($runningValue, $field, $bytes);
+            case Fixed64::class:
+                if ($next[0] === '-') {
+                    throw new \RuntimeException('Fixed64 requires a non-negative integer');
+                }
+                if (extension_loaded('bcmath')) {
+                    $lo = (int)bcmod($next, self::INT32_MAX);
+                    $hi = (int)bcdiv($next, self::INT32_MAX);
+                    $bytes = pack('V2', $lo, $hi);
+                } else {
+                    if (extension_loaded('gmp')) {
+                        $lo = gmp_intval(gmp_mod($next, self::INT32_MAX));
+                        $hi = gmp_intval(gmp_div($next, self::INT32_MAX));
+                        $bytes = pack('V2', $lo, $hi);
+                    } else {
+                        throw new \RuntimeException('GMP or bcmath extension required for string maths');
+                    }
+                }
+                $runningValue->appendTag(ProtoWireType::Double, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+            case Int64::class:
+                $negative = $next[0] === '-';
+                $bytes = '';
+                $value = $next;
+                if (extension_loaded('bcmath')) {
+                    if ($negative) {
+                        $value = bcadd(bcpow('2', '64'), $value);
+                    }
+                    while (bccomp($value, '127') > 0) {
+                        $byte = bcadd(bcmod($value, '128'), '128');
+                        $bytes .= chr((int)$byte);
+                        $value = bcdiv($value, '128', 0);
+                    }
+                    $bytes .= chr((int)$value);
+                } else {
+                    if (extension_loaded('gmp')) {
+                        $value = gmp_init($value);
+                        if ($negative) {
+                            $value = gmp_add(gmp_pow('2', 64), $value);
+                        }
+                        while (gmp_cmp($value, '127') > 0) {
+                            $byte = gmp_intval(gmp_add(gmp_mod($value, '128'), '128'));
+                            $bytes .= chr($byte);
+                            $value = gmp_div_q($value, '128');
+                        }
+                        $bytes .= chr(gmp_intval($value));
+                    } else {
+                        throw new \RuntimeException('GMP or bcmath extension required for string maths');
+                    }
+                }
+                $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+            case SFixed64::class:
+                $negative = $next[0] === '-';
+                if (extension_loaded('bcmath')) {
+                    if ($negative) {
+                        $next = bcadd(bcpow('2', '64'), $next);
+                    }
+                    $lo = (int)bcmod($next, self::INT32_MAX);
+                    $hi = (int)bcdiv($next, self::INT32_MAX);
+                    $bytes = pack('V2', $lo, $hi);
+                } else {
+                    if (extension_loaded('gmp')) {
+                        $next = gmp_init($next);
+                        if (gmp_sign($next) === -1) {
+                            $next = gmp_add(gmp_pow('2', 64), $next);
+                        }
+                        $lo = gmp_intval(gmp_mod($next, self::INT32_MAX));
+                        $hi = gmp_intval(gmp_div_q($next, self::INT32_MAX));
+                        $bytes = pack('V2', $lo, $hi);
+                    } else {
+                        throw new \RuntimeException('GMP or bcmath extension required for string maths');
+                    }
+                }
+                $runningValue->appendTag(ProtoWireType::Double, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+            case UInt32::class:
+            case UInt64::class:
+                $negative = $next[0] === '-';
+                if ($negative) {
+                    throw new \RuntimeException('UInt32 requires a non-negative integer');
+                }
+                $bytes = '';
+                if (extension_loaded('bcmath')) {
+                    $next = bcmod($next, self::INT32_MAX);
+                    while (bccomp($next, '127') > 0) {
+                        $byte = bcadd(bcmod($next, '128'), '128');
+                        $bytes .= chr((int)$byte);
+                        $next = bcdiv($next, '128', 0);
+                    }
+                    $bytes .= chr((int)$next);
+                } else {
+                    if (extension_loaded('gmp')) {
+                        $next = gmp_init($next);
+                        while (gmp_cmp($next, '127') > 0) {
+                            $byte = gmp_add(gmp_mod($next, '128'), '128');
+                            $bytes .= chr(gmp_intval($byte));
+                            $next = gmp_div_q($next, '128');
+                        }
+                        $bytes .= chr(gmp_intval($next));
+                    } else {
+                        throw new \RuntimeException('GMP or bcmath extension required for string maths');
+                    }
+                }
+                $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+                $runningValue->appendBytes($bytes);
+                break;
+        }
+
+        return $runningValue;
+    }
+
+    public function serializeInt(mixed $runningValue, Field $field, ?int $next): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+
+        if ($next === null) {
+            $runningValue->skipTag();
+            return $runningValue;
+        }
+
+        $typeField = $field->typeField === null ? null : get_class($field->typeField);
+
+        switch ($typeField) {
+            case Int32::class:
+            case UInt32::class:
+                $next = $next & self::FULL32;
+            // fall through on purpose after truncating to 32-bit
+            case null:
+            case Int64::class:
+            case UInt64::class:
+                $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+                $runningValue->appendVarInt($next);
+                break;
+            case Fixed32::class:
+            case SFixed32::class:
+                $runningValue->appendTag(ProtoWireType::Single, $field->fieldNum);
+                $bytes = $next & self::FULL32;
+                $bytes = pack('V', $bytes);
+                $runningValue->appendBytes($bytes);
+                break;
+            case SInt32::class:
+                $bytes = (($next << 1) ^ ($next >> 31)) & self::FULL32;
+                $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+                $runningValue->appendVarInt($bytes);
+                break;
+            case SInt64::class:
+                $bytes = ($next << 1) ^ ($next >> 63);
+                $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+                $runningValue->appendVarInt($bytes);
+                break;
+            case Fixed64::class:
+            case SFixed64::class:
+                $runningValue->appendTag(ProtoWireType::Double, $field->fieldNum);
+                $lo = $next & self::FULL32;
+                $hi = ($next >> 32) & self::FULL32;
+                $bytes = pack('V2', $lo, $hi);
+                $runningValue->appendBytes($bytes);
+                break;
+        }
+
+        return $runningValue;
+    }
+
+    public function serializeBool(mixed $runningValue, Field $field, ?bool $next): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+        if ($next === null) {
+            $runningValue->skipTag();
+            return $runningValue;
+        }
+
+        $runningValue->appendTag(ProtoWireType::VarInt, $field->fieldNum);
+        $runningValue->appendVarInt($next ? 1 : 0);
+
+        return $runningValue;
+    }
+
+    public function serializeSequence(mixed $runningValue, Field $field, Sequence $next, Serializer $serializer): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+        $runningValue->lockFieldNumber();
+        foreach($next->items as $nextItem) {
+            $serializer->serialize($nextItem->value, $runningValue, $nextItem->field);
+        }
+        $runningValue->unlockFieldNumber();
+        return $runningValue;
+    }
+
+    public function serializeDictionary(mixed $runningValue, Field $field, Dict $next, Serializer $serializer): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+
+        foreach($next->items as $item) {
+            $map = new RunningValue();
+            // field 1 is key
+            $key = Field::create($item->field->serializedName, 'string');
+            $serializer->serialize($item->field->serializedName, $map, $key);
+
+            // field 2 is value
+            $serializer->serialize($item->value, $map, $item->field->with(fieldNum: 2));
+
+            // prepend to current value
+            $runningValue->appendTag(ProtoWireType::LengthDelimited, $field->fieldNum);
+            $bytes = $map->bytes;
+            $runningValue->appendVarInt(strlen($bytes));
+            $runningValue->appendBytes($bytes);
+        }
+
+        return $runningValue;
+    }
+
+    public function serializeObject(mixed $runningValue, Field $field, Dict $next, Serializer $serializer): mixed
+    {
+        $buffer = new RunningValue();
+
+        foreach($next->items as $nextItem) {
+            $serializer->serialize($nextItem->value, $buffer, $nextItem->field);
+        }
+
+        if($field !== self::$root) {
+            $runningValue->appendTag(ProtoWireType::LengthDelimited, $field->fieldNum);
+            $runningValue->appendVarInt(strlen($buffer->bytes));
+            $runningValue->appendBytes($buffer->bytes);
+        } else {
+            $runningValue->appendBytes($buffer->bytes);
+        }
+
+        return $runningValue;
+    }
+
+    public function serializeNull(mixed $runningValue, Field $field, mixed $next): RunningValue
+    {
+        assert($runningValue instanceof RunningValue);
+        $runningValue->skipTag();
+        return $runningValue;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This contains and merges with https://github.com/Crell/Serde/pull/84.

This adds the formatter for protobuf and provides serialization for all the different types introduced in #86. Each type has slightly different encoding which needs to be correct for other systems to communicate with PHP. The only issue is that PHP doesn’t support unsigned integers. This means that any negative number in PHP going to the unsigned integer types is not actually negative (see: [twos-complement](https://en.wikipedia.org/wiki/Two%27s_complement)), but the "sign-bit" is used as part of the number. Further, this support also needs to function on 32-bit systems; thus it allows using "large numbers" in a string — assuming the developer is using `bcmath` or `gmp` for large integers.

## Motivation and context

Protobuffers are a binary format for storing structured data, and Serde is well suited for this.

## How has this been tested?

This is from a larger work and I’m migrating it out. It’s battletested, but formal tests will come when I finish porting the deformatter.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
