### PR TITLE
Allow serialization/unserialization of objects on mixed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `Serde` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 1.4.0 - DATE
+
+### Added
+- A new `MixedField` type field is available for use on `mixed` properties. If specified, it allows specifying a preferred object type that an array-ish value will be cast into when deserializing.  If the object deserialiation fails, the whole deserialization will fail.
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Serializing an object that is assigned to a `mixed` field will no longer generate a circular reference error.
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## 1.3.2 - 2024-12-06
 
 ### Added

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -371,6 +371,9 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
 
         if ($this->phpType === $valueType) {
             $valid = true;
+        } elseif ($this->phpType === 'mixed') {
+            // From a type perspective, mixed accepts anything.
+            $valid = true;
         } elseif ($this->nullable && $valueType === 'null') {
             $valid = true;
         } elseif (is_object($value) || class_exists($this->phpType) || interface_exists($this->phpType)) {

--- a/src/Attributes/MixedField.php
+++ b/src/Attributes/MixedField.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Attributes;
+
+use Crell\AttributeUtils\SupportsScopes;
+use Crell\Serde\TypeField;
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class MixedField implements TypeField, SupportsScopes
+{
+    public function __construct(
+        public readonly string $suggestedType,
+        protected readonly array $scopes = [null],
+    ) {}
+
+    public function scopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function acceptsType(string $type): bool
+    {
+        return $type === 'mixed';
+    }
+
+    public function validate(mixed $value): bool
+    {
+        return true;
+    }
+}

--- a/src/Attributes/MixedField.php
+++ b/src/Attributes/MixedField.php
@@ -4,13 +4,26 @@ declare(strict_types=1);
 
 namespace Crell\Serde\Attributes;
 
+use Attribute;
 use Crell\AttributeUtils\SupportsScopes;
 use Crell\Serde\TypeField;
-use Attribute;
 
+/**
+ * Specifies how a mixed field should be deserialized.
+ *
+ * In particular, it allows specifying a class type to which an array-ish
+ * value should be deserialized.
+ */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class MixedField implements TypeField, SupportsScopes
 {
+    /**
+     * @param string $suggestedType
+     *   The class name that an array-ish value should be deserialized into.
+     *   Primitive values will be left as is when deserializing.
+     * @param array<string|null> $scopes
+     *   The scopes in which this attribute should apply.
+     */
     public function __construct(
         public readonly string $suggestedType,
         protected readonly array $scopes = [null],

--- a/src/PropertyHandler/MixedExporter.php
+++ b/src/PropertyHandler/MixedExporter.php
@@ -6,6 +6,7 @@ namespace Crell\Serde\PropertyHandler;
 
 use Crell\Serde\Attributes\DictionaryField;
 use Crell\Serde\Attributes\Field;
+use Crell\Serde\Attributes\MixedField;
 use Crell\Serde\CollectionItem;
 use Crell\Serde\Deserializer;
 use Crell\Serde\Dict;
@@ -40,6 +41,12 @@ class MixedExporter implements Importer, Exporter
         // case, we're guaranteed that the $source is array-based, so we can introspect
         // it directly.
         $type = \get_debug_type($source[$field->serializedName]);
+
+        /** @var MixedField|null $typeField */
+        $typeField = $field->typeField;
+        if ($typeField && class_exists($typeField->suggestedType) && $type === 'array') {
+            $type = $typeField->suggestedType;
+        }
 
         return $deserializer->deserialize($source, Field::create(
             serializedName: $field->serializedName,

--- a/src/PropertyHandler/MixedExporter.php
+++ b/src/PropertyHandler/MixedExporter.php
@@ -26,7 +26,9 @@ class MixedExporter implements Importer, Exporter
 {
     public function exportValue(Serializer $serializer, Field $field, mixed $value, mixed $runningValue): mixed
     {
-        return $serializer->serialize($value, $runningValue, Field::create(
+        // We need to bypass the circular reference check in Serializer::serialize(),
+        // or else an object would always fail here.
+        return $serializer->doSerialize($value, $runningValue, Field::create(
             serializedName: $field->serializedName,
             phpType: \get_debug_type($value),
         ));

--- a/src/PropertyHandler/MixedExporter.php
+++ b/src/PropertyHandler/MixedExporter.php
@@ -20,8 +20,11 @@ use Crell\Serde\TypeCategory;
  * Exporter/importer for `mixed` properties.
  *
  * This class makes a good-faith attempt to detect the type of a given field by its value.
- * It currently does not work for objects, and on import it works only on array-based
- * formats (JSON, YAML, TOML, etc.)
+ * On import, it currently works only on array-based formats (JSON, YAML, TOML, etc.)
+ *
+ * To deserialize into an object, the property must have the MixedField attribute.
+ *
+ * @see MixedField
  */
 class MixedExporter implements Importer, Exporter
 {

--- a/tests/Records/MixedValObject.php
+++ b/tests/Records/MixedValObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\MixedField;
+
+class MixedValObject
+{
+    public function __construct(
+        #[MixedField(Point::class)]
+        public mixed $val
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -1060,6 +1060,7 @@ abstract class SerdeTestCases extends TestCase
         yield 'float' => [new MixedVal(3.14)];
         yield 'sequence' => [new MixedVal(['a', 'b', 'c'])];
         yield 'dict' => [new MixedVal(['a' => 'A', 'b' => 'B', 'c' => 'C'])];
+        yield 'object' => [new MixedVal(new Point(1, 2, 3))];
     }
 
     public function mixed_val_property_validate(mixed $serialized, mixed $data): void


### PR DESCRIPTION
## Description

Previously, `mixed` properties didn't support objects.  They would fail with a circular dependency due to how mixed properties are handled.  That's sub-optimal, especially when union types are not supported.

This PR resolves the circular dependency, albeit in a slightly not-nice way.  Additionally, it provides support for deserializing into an object on a mixed property, but at the expense of allowing arrays when deserializing.  Frankly that's an edge case, and if you have a `mixed` property it should be serialized only, but some APIs are dumb, so we provide some support for it.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This fix was sponsored by my employer, [MakersHub](https://makershub.ai/).