### PR TITLE
Fix deprecation when passing `null` as first parameter to `array_key_exists`

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -20,6 +20,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   coverage: xdebug
+                  ini-values: error_reporting=E_ALL
                   tools: composer:v2
             - run: composer install --no-progress ${{ matrix.composer-flags }}
             - run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}

--- a/src/Formatter/ArrayBasedDeformatter.php
+++ b/src/Formatter/ArrayBasedDeformatter.php
@@ -236,7 +236,7 @@ trait ArrayBasedDeformatter
             first(static fn (string $name): bool => isset($decoded[$name]))
         );
 
-        if (!array_key_exists($key, $decoded)) {
+        if ($key === null || !array_key_exists($key, $decoded)) {
             return DeformatterResult::Missing;
         }
 


### PR DESCRIPTION
## Description

This PR fixes a deprecation emitted when `$key` is `null` when passed to `array_key_exists` function. 

## Motivation and context

In the context of adopting the library in a proof of concept, I encountered a deprecation notice and created #102 to follow up on it. This PR fixes #102

## How has this been tested?

Existing test suite already covers this scenario, but is now made visible by running the tests with `error_reporting=E_ALL`. can be confirmed by running `vendor/bin/phpunit` on the first commit.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
