### PR TITLE
Allow Enum objects part of a type map to be serialized and deserialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,37 @@ interface Product {}
 
 And both `Sale` and `Order` will still serialize with the appropriate key.
 
+#### Type mapped enums
+
+When an enum is used as part of a type map, its backing value will be serialized with the `value` property.
+
+Consider the following enum:
+```php
+enum Genre: string {
+    case Action = 'action';
+    case Adventure = 'adventure';
+}
+```
+
+And consider the following TypeMap
+```php
+use Crell\Serde\Attributes\StaticTypeMap;
+
+#[StaticTypeMap(key: 'type', map: [
+    'genre' => Genre::class,
+])]
+interface Book {}
+```
+
+Serializing the `Genre::Action` enum as part of the TypeMap will result in the following serialized representation:
+
+```json
+{
+    "type": "genre",
+    "value": "action"
+}
+```
+
 #### Dynamic type maps
 
 Type Maps may also be provided directly to the Serde object when it is created.  Any object that implements `TypeMap` may be used.  This is most useful when the list of possible classes is dynamic based on user configuration, database values, what plugins are installed in your application, etc.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "~8.2",
-        "crell/attributeutils": "~1.3",
+        "crell/attributeutils": "dev-master#a118b55 as 1.3.1",
         "crell/fp": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "~8.2",
-        "crell/attributeutils": "dev-master#a118b55 as 1.3.1",
+        "crell/attributeutils": "~1.3.1",
         "crell/fp": "~1.0"
     },
     "require-dev": {

--- a/src/PropertyHandler/EnumExporter.php
+++ b/src/PropertyHandler/EnumExporter.php
@@ -5,17 +5,48 @@ declare(strict_types=1);
 namespace Crell\Serde\PropertyHandler;
 
 use Crell\Serde\Attributes\Field;
+use Crell\Serde\CollectionItem;
 use Crell\Serde\DeformatterResult;
 use Crell\Serde\Deserializer;
+use Crell\Serde\Dict;
 use Crell\Serde\Serializer;
 use Crell\Serde\TypeCategory;
 use Crell\Serde\TypeMismatch;
 use ReflectionEnum;
+use function Crell\fp\pipe;
+use function Crell\fp\reduce;
 
 class EnumExporter implements Exporter, Importer
 {
     public function exportValue(Serializer $serializer, Field $field, mixed $value, mixed $runningValue): mixed
     {
+        if ($field->typeCategory !== TypeCategory::UnitEnum && $map = $serializer->typeMapper->typeMapForField($field)) {
+            // This lets us read private values without messing with the Reflection API.
+            // The object_vars business is to let us differentiate between a value set to null
+            // and an uninitialized value, which in this rare case are meaningfully different.
+            // @todo This may benefit from caching get_object_vars(), but that will be tricky.
+            $propReader = (fn (string $prop): mixed
+                => array_key_exists($prop, get_object_vars($this)) ? $this->$prop : DeformatterResult::Missing)->bindTo($value, $value);
+
+            /** @var Dict $dict */
+            $dict = pipe(
+                $serializer->propertiesFor($value::class),
+                reduce(new Dict(), fn(Dict $dict, Field $f) => $dict),
+            );
+
+            $f = Field::create(serializedName: $map->keyField(), phpType: 'string');
+            // The type map field MUST come first so that streaming deformatters
+            // can know their context.
+            $dict->items = [
+                new CollectionItem(field: $f, value: $map->findIdentifier($value::class)),
+            ];
+
+            $result = $serializer->formatter->serializeObject($runningValue, $field, $dict, $serializer);
+            $result[0]['value'] = $value->value;
+
+            return $result;
+        }
+
         $scalar = $value->value ?? $value->name;
 
         // PHPStan can't handle match() without a default.
@@ -33,6 +64,10 @@ class EnumExporter implements Exporter, Importer
 
     public function importValue(Deserializer $deserializer, Field $field, mixed $source): mixed
     {
+        if ($field->typeCategory !== TypeCategory::UnitEnum && $deserializer->typeMapper->typeMapForField($field) !== null) {
+            $source = [$source[0]['value']];
+        }
+
         // It's kind of amusing that both of these work, but they work.
         $val = match ($field->typeCategory) {
             TypeCategory::UnitEnum, TypeCategory::StringEnum => $deserializer->deformatter->deserializeString($source, $field),

--- a/src/TypeMapOnNonObjectField.php
+++ b/src/TypeMapOnNonObjectField.php
@@ -17,7 +17,7 @@ class TypeMapOnNonObjectField extends InvalidArgumentException
 
         $new->field = $field;
 
-        $new->message = sprintf('Type maps may only be applied to object or array fields. Tried to apply type map to field %s of type %s.  Honestly I do not know how you even got here.', $field->phpName ?? $field->serializedName, $field->phpType);
+        $new->message = sprintf('Type maps may only be applied to object, backed enums or array fields. Tried to apply type map to field %s of type %s.  Honestly I do not know how you even got here.', $field->phpName ?? $field->serializedName, $field->phpType);
 
         return $new;
     }

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -20,7 +20,7 @@ class TypeMapper
 
     public function typeMapForField(Field $field): ?TypeMap
     {
-        if (!in_array($field->typeCategory, [TypeCategory::Object, TypeCategory::Array], true)) {
+        if (!in_array($field->typeCategory, [TypeCategory::Object, TypeCategory::Array, TypeCategory::IntEnum, TypeCategory::StringEnum], true)) {
             throw TypeMapOnNonObjectField::create($field);
         }
 

--- a/tests/ArrayBasedFormatterTestCases.php
+++ b/tests/ArrayBasedFormatterTestCases.php
@@ -75,7 +75,7 @@ abstract class ArrayBasedFormatterTestCases extends SerdeTestCases
         self::assertEquals('C', $toTest['c']);
     }
 
-    protected function static_type_map_validate(mixed $serialized): void
+    protected function static_typemap_validate(mixed $serialized): void
     {
         $toTest = $this->arrayify($serialized);
 

--- a/tests/Records/TypeMappedEnum.php
+++ b/tests/Records/TypeMappedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+enum TypeMappedEnum: int implements TypeMappedInterface
+{
+    case A = 1;
+    case B = 2;
+}

--- a/tests/Records/TypeMappedInterface.php
+++ b/tests/Records/TypeMappedInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\StaticTypeMap;
+
+#[StaticTypeMap(key: 'type', map: [
+    'enum' => TypeMappedEnum::class,
+    'object' => TypeMappedObject::class,
+])]
+interface TypeMappedInterface
+{
+}

--- a/tests/Records/TypeMappedMixedElements.php
+++ b/tests/Records/TypeMappedMixedElements.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+
+final readonly class TypeMappedMixedElements
+{
+    /** @param list<TypeMappedInterface> $elements */
+    public function __construct(
+        #[SequenceField(arrayType: TypeMappedInterface::class)]
+        public array $elements = [],
+    ) {
+    }
+}

--- a/tests/Records/TypeMappedObject.php
+++ b/tests/Records/TypeMappedObject.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+class TypeMappedObject implements TypeMappedInterface
+{
+    public function __construct(
+        public int $id = 1,
+    ) {}
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -102,6 +102,9 @@ use Crell\Serde\Records\TransitiveField;
 use Crell\Serde\Records\TraversableInts;
 use Crell\Serde\Records\TraversablePoints;
 use Crell\Serde\Records\Traversables;
+use Crell\Serde\Records\TypeMappedEnum;
+use Crell\Serde\Records\TypeMappedMixedElements;
+use Crell\Serde\Records\TypeMappedObject;
 use Crell\Serde\Records\UnionTypeSubTypeField;
 use Crell\Serde\Records\UnionTypeWithInterface;
 use Crell\Serde\Records\UnixTimeExample;
@@ -206,6 +209,7 @@ abstract class SerdeTestCases extends TestCase
     #[DataProvider('mixed_val_property_object_examples')]
     #[DataProvider('union_types_examples')]
     #[DataProvider('compound_types_examples')]
+    #[DataProvider('interface_typemap_and_enum_permutations')]
     public function round_trip(object $data): void
     {
         $s = new SerdeCommon(formatters: $this->formatters);
@@ -519,6 +523,22 @@ abstract class SerdeTestCases extends TestCase
                 ],
                 other: ['narf' => 'poink', 'bleep' => 'bloop']
             ),
+        ];
+    }
+
+    /**
+     * specific permutations for cases of using type maps against an interface.
+     */
+    public static function interface_typemap_and_enum_permutations(): iterable
+    {
+        yield 'interface typemap for enum' => [
+            'data' => new TypeMappedMixedElements([TypeMappedEnum::A]),
+        ];
+        yield 'interface typemap for object' => [
+            'data' => new TypeMappedMixedElements([new TypeMappedObject(2)]),
+        ];
+        yield 'interface typemap for enum and object' => [
+            'data' => new TypeMappedMixedElements([TypeMappedEnum::A, new TypeMappedObject(2)]),
         ];
     }
 

--- a/tests/TomlFormatterTest.php
+++ b/tests/TomlFormatterTest.php
@@ -72,6 +72,7 @@ class TomlFormatterTest extends ArrayBasedFormatterTestCases
     #[DataProvider('mixed_val_property_object_examples')]
     #[DataProvider('union_types_examples')]
     #[DataProvider('compound_types_examples')]
+    #[DataProvider('interface_typemap_and_enum_permutations')]
     public function round_trip(object $data): void
     {
         if ($this->dataName() === 'empty_values') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This proposed change aims to allow Enum objects part of a TypeMap to be serialized and deserialized by establishing a serialized structure expected when working with enums in this context.

## Motivation and context

fixes #10 

## How has this been tested?

`composer all-checks` helped validate the proposed changes.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

