### PR TITLE
Allow deserialization of nullable arrays

### DIFF
--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -375,7 +375,9 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
     {
         $valueType = \get_debug_type($value);
 
-        if ($this->phpType === $valueType) {
+        if ($this->phpType === 'array' && $this->nullable && $value === null) {
+            return true;
+        } elseif ($this->phpType === $valueType) {
             $valid = true;
         } elseif ($this->phpType === 'mixed') {
             // From a type perspective, mixed accepts anything.

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -375,9 +375,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
     {
         $valueType = \get_debug_type($value);
 
-        if ($this->phpType === 'array' && $this->nullable && $value === null) {
-            return true;
-        } elseif ($this->phpType === $valueType) {
+        if ($this->phpType === $valueType) {
             $valid = true;
         } elseif ($this->phpType === 'mixed') {
             // From a type perspective, mixed accepts anything.
@@ -414,6 +412,18 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
                 // in any other case.
                 default => true,
             };
+        }
+
+        /**
+         * We're returning early under this conditions due to the fact that a SequenceField
+         * instance call to `validate` with a null value would throw an exception.
+         *
+         * Unfortunately at this moment, only the value can be passed to the `validate`,
+         * meaning we cannot check `$this->nullable`, which would allow us to have this check inside the `validate`
+         * method of the SequenceField instance.
+         */
+        if ($this->phpType === 'array' && $this->nullable && $value === null && $valid) {
+            return true;
         }
 
         // The value validates if it passes the simple check above,

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -373,14 +373,18 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
      */
     public function validate(mixed $value): bool
     {
+        if ($this->nullable && $value === null) {
+            // If the field is nullable and the value is null, we know it's valid.
+            // No need to call the validate() method further down.
+            return true;
+        }
+
         $valueType = \get_debug_type($value);
 
         if ($this->phpType === $valueType) {
             $valid = true;
         } elseif ($this->phpType === 'mixed') {
             // From a type perspective, mixed accepts anything.
-            $valid = true;
-        } elseif ($this->nullable && $valueType === 'null') {
             $valid = true;
         } elseif (is_object($value) || class_exists($this->phpType) || interface_exists($this->phpType)) {
             // For objects, do a type check and we're done.
@@ -412,18 +416,6 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
                 // in any other case.
                 default => true,
             };
-        }
-
-        /**
-         * We're returning early under this conditions due to the fact that a SequenceField
-         * instance call to `validate` with a null value would throw an exception.
-         *
-         * Unfortunately at this moment, only the value can be passed to the `validate`,
-         * meaning we cannot check `$this->nullable`, which would allow us to have this check inside the `validate`
-         * method of the SequenceField instance.
-         */
-        if ($this->phpType === 'array' && $this->nullable && $value === null && $valid) {
-            return true;
         }
 
         // The value validates if it passes the simple check above,

--- a/tests/Records/NullablePointList.php
+++ b/tests/Records/NullablePointList.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\SequenceField;
+
+readonly final class NullablePointList
+{
+    /**
+     * @param list<Point>|null $points
+     */
+    public function __construct(
+        #[SequenceField(arrayType: Point::class)]
+        public array|null $points = null,
+    ) {
+    }
+}

--- a/tests/Records/NullablePointListWithoutConstructor.php
+++ b/tests/Records/NullablePointListWithoutConstructor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\Records;
+
+use Crell\Serde\Attributes\Field;
+use Crell\Serde\Attributes\SequenceField;
+
+readonly final class NullablePointListWithoutConstructor
+{
+    /**
+     * When the object does not have a constructor, We need to specify the default value.
+     *
+     * In cases of readonly properties, we can't use the default value
+     * as the property can't have a default value in that scenario.
+     *
+     * Therefore, #[Field(default: null)] must be used in such circumstances
+     * to avoid the object instantiation with uninitialized properties.
+     */
+    #[Field(default: null)]
+    #[SequenceField(arrayType: Point::class)]
+    public array|null $points;
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -68,6 +68,8 @@ use Crell\Serde\Records\NativeSerUn;
 use Crell\Serde\Records\NestedFlattenObject;
 use Crell\Serde\Records\NestedObject;
 use Crell\Serde\Records\NonPromotedDefault;
+use Crell\Serde\Records\NullablePointListWithoutConstructor;
+use Crell\Serde\Records\NullablePointList;
 use Crell\Serde\Records\NullArrays;
 use Crell\Serde\Records\NullProps;
 use Crell\Serde\Records\OptionalPoint;
@@ -120,6 +122,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Crell\Serde\Records\UnionTypes;
+use ReflectionClass;
 
 /**
  * Testing base class.
@@ -351,6 +354,16 @@ abstract class SerdeTestCases extends TestCase
             'data' => new DateTimeExtendsExample(
                 extendsProperty: new DateTimeExtends('2025-12-25 12:34:56.789'),
             ),
+        ];
+        yield 'nullable_list_with_constructor' => [
+            'data' => new NullablePointList(),
+        ];
+
+        $reflected = new ReflectionClass(NullablePointListWithoutConstructor::class);
+        $instance = $reflected->newInstanceWithoutConstructor();
+        $reflected->getProperty('points')->setValue($instance, null);
+        yield 'nullable_list_without_constructor' => [
+            'data' => $instance,
         ];
     }
 


### PR DESCRIPTION
## Description

Allows deserialization of nullable arrays

## Motivation and context

This was a case encountered when dealing with an external system as part of a project I was working on. With this change, the library can now deserialize nullable arrays.

closes #107 

## How has this been tested?

Automated test based on the reproduction example linked to the issue were added covering the round trip of serializing/deserializing a nullable array.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
