### PR TITLE
Fix PHPStan reported issues

### DIFF
--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -239,7 +239,7 @@ class Field implements FromReflectionProperty, HasSubAttributes, Excludable, Sup
         // If there is no requireValue flag set, inherit it from the class attribute.
         $this->requireValue ??= $class->requireValues;
         $this->rename ??= $class->renameWith ?? null;
-        $this->omitIfNull ??= $class->omitNullFields ?? false;
+        $this->omitIfNull ??= $class->omitNullFields;
     }
 
     protected function getDefaultValueFromConstructor(\ReflectionProperty $subject): mixed

--- a/src/PropertyHandler/EnumExporter.php
+++ b/src/PropertyHandler/EnumExporter.php
@@ -54,7 +54,6 @@ class EnumExporter implements Exporter, Importer
             // @phpstan-ignore-next-line
             TypeCategory::UnitEnum => (new ReflectionEnum($field->phpType))->getCase($val)->getValue(),
             TypeCategory::IntEnum, TypeCategory::StringEnum => $field->phpType::from($val),
-            default => throw TypeMismatch::create($field->phpName, $field->phpType, get_debug_type($source)),
         };
     }
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and context

These PHPStan errors started being flagged without code changes:

```log
Error: Property Crell\Serde\Attributes\ClassSettings::$omitNullFields (bool) on left side of ?? is not nullable.
Error: Match arm comparison between Crell\Serde\TypeCategory::StringEnum and Crell\Serde\TypeCategory::StringEnum is always true.
 ------ -----------------------------------------------------------------------
  Line   src/Attributes/Field.php
 ------ -----------------------------------------------------------------------
  242    Property Crell\Serde\Attributes\ClassSettings::$omitNullFields (bool)
         on left side of ?? is not nullable.
         🪪  nullCoalesce.property
 ------ -----------------------------------------------------------------------

 ------ -----------------------------------------------------------------------
  Line   src/PropertyHandler/EnumExporter.php
 ------ -----------------------------------------------------------------------
  56     Match arm comparison between Crell\Serde\TypeCategory::StringEnum and
         Crell\Serde\TypeCategory::StringEnum is always true.
         🪪  match.alwaysTrue
         💡  Remove remaining cases below this one and this error will
         disappear too.
 ------ -----------------------------------------------------------------------
```

The changes in this PR solve the new errors flagged under PHPStan version 2.1.51

## How has this been tested?

Automated checks with `composer all-checks`
