### PR TITLE
Keep null for nullable scalar fields in weak mode

### DIFF
--- a/src/Formatter/ArrayBasedDeformatter.php
+++ b/src/Formatter/ArrayBasedDeformatter.php
@@ -41,6 +41,9 @@ trait ArrayBasedDeformatter
         }
 
         // Weak mode.
+        if ($field->nullable && is_null($value)) {
+            return null;
+        }
         return (int)($decoded[$field->serializedName]);
     }
 
@@ -60,6 +63,9 @@ trait ArrayBasedDeformatter
         }
 
         // Weak mode.
+        if ($field->nullable && is_null($value)) {
+            return null;
+        }
         return (float)($decoded[$field->serializedName]);
     }
 
@@ -79,6 +85,9 @@ trait ArrayBasedDeformatter
         }
 
         // Weak mode.
+        if ($field->nullable && is_null($value)) {
+            return null;
+        }
         return (bool)($decoded[$field->serializedName]);
     }
 
@@ -98,6 +107,9 @@ trait ArrayBasedDeformatter
         }
 
         // Weak mode.
+        if ($field->nullable && is_null($value)) {
+            return null;
+        }
         return (string)($value);
     }
 

--- a/tests/ArrayFormatterTest.php
+++ b/tests/ArrayFormatterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Crell\Serde;
 
 use Crell\Serde\Formatter\ArrayFormatter;
-use Crell\Serde\NonStrict\NonStrictNullableProperties;
 use Crell\Serde\PropertyHandler\EnumOnArrayImporter;
 use Crell\Serde\Records\BackedSize;
 use Crell\Serde\Records\LiteralEnums;
@@ -85,26 +84,6 @@ class ArrayFormatterTest extends ArrayBasedFormatterTestCases
         $expected = new LiteralEnums(size: Size::Medium, backedSize: BackedSize::Small);
 
         self::assertEquals($expected, $result);
-    }
-
-    #[Test]
-    public function non_strict_null_stays_null_on_nullable_fields(): void
-    {
-        $s = new SerdeCommon(formatters: $this->formatters);
-
-        $serialized = [
-            'int' => null,
-            'float' => null,
-            'string' => null,
-            'bool' => null,
-        ];
-
-        $result = $s->deserialize($serialized, from: 'array', to: NonStrictNullableProperties::class);
-
-        self::assertNull($result->int);
-        self::assertNull($result->float);
-        self::assertNull($result->string);
-        self::assertNull($result->bool);
     }
 
     public static function non_strict_properties_examples(): iterable

--- a/tests/ArrayFormatterTest.php
+++ b/tests/ArrayFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Crell\Serde;
 
 use Crell\Serde\Formatter\ArrayFormatter;
+use Crell\Serde\NonStrict\NonStrictNullableProperties;
 use Crell\Serde\PropertyHandler\EnumOnArrayImporter;
 use Crell\Serde\Records\BackedSize;
 use Crell\Serde\Records\LiteralEnums;
@@ -84,6 +85,26 @@ class ArrayFormatterTest extends ArrayBasedFormatterTestCases
         $expected = new LiteralEnums(size: Size::Medium, backedSize: BackedSize::Small);
 
         self::assertEquals($expected, $result);
+    }
+
+    #[Test]
+    public function non_strict_null_stays_null_on_nullable_fields(): void
+    {
+        $s = new SerdeCommon(formatters: $this->formatters);
+
+        $serialized = [
+            'int' => null,
+            'float' => null,
+            'string' => null,
+            'bool' => null,
+        ];
+
+        $result = $s->deserialize($serialized, from: 'array', to: NonStrictNullableProperties::class);
+
+        self::assertNull($result->int);
+        self::assertNull($result->float);
+        self::assertNull($result->string);
+        self::assertNull($result->bool);
     }
 
     public static function non_strict_properties_examples(): iterable

--- a/tests/NonStrict/NonStrictNullableProperties.php
+++ b/tests/NonStrict/NonStrictNullableProperties.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Serde\NonStrict;
+
+use Crell\Serde\Attributes\Field;
+
+class NonStrictNullableProperties
+{
+    public function __construct(
+        #[Field(strict: false)]
+        public readonly ?int $int = null,
+        #[Field(strict: false)]
+        public readonly ?float $float = null,
+        #[Field(strict: false)]
+        public readonly ?string $string = null,
+        #[Field(strict: false)]
+        public readonly ?bool $bool = null,
+    ) {
+    }
+}

--- a/tests/SerdeTestCases.php
+++ b/tests/SerdeTestCases.php
@@ -11,6 +11,7 @@ use Crell\Serde\Attributes\ReducingTransitiveTypeField;
 use Crell\Serde\Attributes\StaticTypeMap;
 use Crell\Serde\Attributes\TransitiveTypeField;
 use Crell\Serde\Formatter\SupportsCollecting;
+use Crell\Serde\NonStrict\NonStrictNullableProperties;
 use Crell\Serde\PropertyHandler\Exporter;
 use Crell\Serde\PropertyHandler\ObjectExporter;
 use Crell\Serde\PropertyHandler\ObjectImporter;
@@ -315,6 +316,9 @@ abstract class SerdeTestCases extends TestCase
         ];
         yield 'empty_values' => [
             'data' => new EmptyData('beep', null),
+        ];
+        yield 'non_strict_null_stays_null' => [
+            'data' => new NonStrictNullableProperties(),
         ];
         yield 'native_object_serialization' => [
             'data' => new NativeSerUn(


### PR DESCRIPTION
## Description

The weak-mode (`#[Field(strict: false)]`) branches of `deserializeInt`, `deserializeFloat`, `deserializeBool` and `deserializeString` cast the value unconditionally, so a `null` on a nullable field is coerced to `0`, `0.0`, `false` or `""`. The strict branches already special-case `$field->nullable && is_null($value)`, so I added the same guard before each weak-mode cast.

## Motivation and context

Deserializing `null` into a `?int` (etc.) marked `strict: false` should keep the value `null`, not turn it into `0`. The return types already permit `null`, so only the cast was wrong. fixes #110

## How has this been tested?

`composer test` passes (539 tests). Added `non_strict_null_stays_null_on_nullable_fields` in `ArrayFormatterTest`, which fails on the current code (`0` is not null) and passes with the guard in place. PHPStan reports no new errors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
