### PR TITLE
Regenerate PHPUnit config to get modern tightened settings.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <!--
-    <coverage>
-    <report>
-      <clover outputFile="build/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
-  -->
-  <testsuites>
-    <testsuite name="Serde Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
-  <source>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory="build/phpunit.cache"
+         executionOrder="depends,defects"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <ini name="display_errors" value="on" />
+        <ini name="display_startup_errors" value="on" />
+        <ini name="error_reporting" value="-1" />
+        <ini name="assert.exceptions" value="1" />
+        <ini name="xdebug.show_show_exception_trace" value="on" />
+    </php>
+
+    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
I was going to resolve #104 piecemeal, but for whatever reason PHPUnit didn't like that.  So I just regenerated it with the new, modern template and tweaked from there.